### PR TITLE
Refactored build scripts to get the package building

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,5 @@
+/* global module */
+
 'use strict';
 
 module.exports = {
@@ -11,6 +13,7 @@ module.exports = {
       },
     ],
     '@babel/preset-react',
+    '@babel/preset-typescript',
   ],
   plugins: [
     ['@babel/plugin-proposal-class-properties'],

--- a/package.json
+++ b/package.json
@@ -13,23 +13,25 @@
   "module": "lib/esm/index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://git@github.com/albertogasparin/react-loosely-lazy.git"
+    "url": "git+https://git@github.com/atlassian-labs/react-loosely-lazy.git"
   },
   "author": "Alberto Gasparin",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/albertogasparin/react-loosely-lazy/issues"
+    "url": "https://github.com/atlassian-labs/react-loosely-lazy/issues"
   },
-  "homepage": "https://github.com/albertogasparin/react-loosely-lazy#readme",
+  "homepage": "https://github.com/atlassian-labs/react-loosely-lazy#readme",
   "scripts": {
-    "clean:build": "rm -rf ./lib",
-    "build:cjs": "babel src/ -d lib/cjs --ignore **/__tests__ --presets @babel/env",
-    "build:esm": "babel src/ -d lib/esm --ignore **/__tests__",
-    "build:flow": "echo lib/cjs lib/esm | xargs -n 1 cp src/index.js.flow",
-    "build": "npm run clean:build -s && npm run build:cjs -s && npm run build:esm -s && npm run build:flow -s",
+    "types": "tsc --noEmit && flow --max-warnings=0",
+    "types:watch": "npm run type-check -- --watch",
+    "build": "npm run build:clean && npm run build:types-cjs && npm run build:types-esm && npm run build:cjs && npm run build:esm",
+    "build:clean": "rm -rf ./lib",
+    "build:types-cjs": "tsc --emitDeclarationOnly --project tsconfig.build.json --outDir lib/cjs && cp src/index.js.flow lib/cjs",
+    "build:types-esm": "tsc --emitDeclarationOnly --project tsconfig.build.json --outDir lib/esm && cp src/index.js.flow lib/esm",
+    "build:cjs": "babel src --out-dir lib/cjs --extensions \".ts,.tsx\" --source-maps inline --ignore src/__tests__ --presets @babel/env",
+    "build:esm": "babel src --out-dir lib/esm --extensions \".ts,.tsx\" --source-maps inline --ignore src/__tests__",
     "test": "jest",
     "test:watch": "jest --watch",
-    "types": "dtslint --expectOnly --localTs node_modules/typescript/lib ./types && tsc && flow --max-warnings=0",
     "lint": "eslint --ext .ts,.tsx,.js src/ && eslint --ext .ts,.tsx,.js examples/",
     "lint:fix": "eslint --ext .ts,.tsx,.js src/ --fix && eslint --ext .ts,.tsx,.js examples/ --fix",
     "preversion": "npm run lint -s && npm run types -s && npm run test -s",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,43 @@
+// @flow
+
+import type { Node, ComponentType } from 'react';
+
+export type MODE = {|
+  RENDER: string,
+  HYDRATE: string,
+|};
+
+export type SETTINGS = {
+  CURRENT_MODE: $ElementType<MODE, 'RENDER'> | $ElementType<MODE, 'HYDRATE'>,
+};
+
+export type LooselyLazy = {|
+  init: (mode: $ElementType<SETTINGS, 'CURRENT_MODE'>) => void,
+|};
+
+type ImportDefaultComponent = {
+  default: ComponentType<any>,
+};
+
+export type Loader = () => Promise<ImportDefaultComponent>;
+
+type LazyComponent = any;
+
+export type lazyForPaint = () => (loader: Loader, opts?: any) => LazyComponent;
+
+export type lazyAfterPaint = () => (
+  loader: Loader,
+  opts?: any
+) => LazyComponent;
+
+export type lazy = () => (loader: Loader, opts?: any) => LazyComponent;
+
+export type LazyWait = (props: {
+  until: boolean,
+  children: Node,
+}) => Node;
+
+export type useLazyPhase = () => {
+  startNextPhase: () => void,
+  resetPhase: () => void,
+};

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,5 +16,5 @@
       "react-loosely-lazy/server": ["src/server"]
     }
   },
-  "include": ["examples/**/*"]
+  "exclude": ["examples/**/*", "src/__tests__/**/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,20 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "esnext",
-    "declaration": true,
-    "outDir": "lib",
-    "esModuleInterop": true,
-    "moduleResolution": "node",
-    "strict": true,
-    "preserveConstEnums": true,
-    "jsx": "preserve",
-    "typeRoots": ["./node_modules/@types", "types"],
-    "baseUrl": ".",
-    "paths": {
-      "react-loosely-lazy": ["src"],
-      "react-loosely-lazy/server": ["src/server"]
-    }
-  },
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"],
   "exclude": ["examples/**/*", "src/__tests__/**/*"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ const generateExampleEntries = function() {
 
   return exampleDirs.reduce((entry, dir) => {
     entry['./' + basename(dir) + '/bundle'] = `${dir}/index`;
+
     return entry;
   }, {});
 };


### PR DESCRIPTION
### Added 

* `tsconfig.build.json` that excludes examples and tests from the build
* `src/index.flow.js` for flow types
* `'@babel/preset-typescript',` to main babel preset
* `"declaration": true` to main `tsconfig.json` 
* New scripts for building, but you can simply run `npm run build` to try the full flow out