### PR TITLE
Remove sync start in createDeferred and fix getBundleUrl

### DIFF
--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -35,6 +35,7 @@ const createApp = ({
   const Fallback = jest.fn(() => <i>Fallback</i>) as any;
   const { mockImport, resolveImport } = createMockImport(Child, ssr && server);
   const lazyFn = phase === PHASE.AFTER_PAINT ? lazyAfterPaint : lazyForPaint;
+  // @ts-ignore - We are mocking the import
   const AsyncComponent = lazyFn(() => mockImport, {
     id: () => './my-component',
     ssr,
@@ -103,10 +104,12 @@ describe('hydrate without priority', () => {
         ssr,
         hydrate,
       });
+
       render(<ClientApp />, {
         hydrate,
         container: document.body.firstChild as HTMLElement,
       });
+
       // expect client to use live fallback ASAP
       expect(Child).not.toHaveBeenCalled();
       expect(Fallback).toHaveBeenCalled();

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,15 +1,24 @@
-export const createMockImport = (value: any, sync: boolean) => {
-  let resolve: { (arg0: { default: any }): void; (value?: unknown): void };
-  const mockImport = sync
-    ? ({
-        then: (fn: (arg0: { default: any }) => any) => fn({ default: value }),
-      } as any)
-    : new Promise(r => {
-        resolve = r;
-      });
+export const createMockImport = (
+  component: jest.Mock<JSX.Element, []>,
+  sync: boolean
+) => {
+  const resolved = { default: component };
+  let resolve: any;
+  let mockImport;
+
+  if (sync) {
+    // This should be the same as the transpiled output from the babel plugin
+    const then = (fn: any) => fn(resolved);
+
+    mockImport = { ...resolved, then };
+  } else {
+    mockImport = new Promise(r => {
+      resolve = r;
+    });
+  }
 
   const resolveImport = async () => {
-    resolve({ default: value });
+    resolve(resolved);
 
     // let react re-render
     await nextTick();

--- a/src/lazy/__tests__/lazy.test.tsx
+++ b/src/lazy/__tests__/lazy.test.tsx
@@ -21,17 +21,17 @@ describe('lazy', () => {
 
     describe('getBundleUrl', () => {
       it('should find the module file in the supplied manifest', () => {
-        const file = 'https://cdn.com/@foo/bar.js';
+        const publicPath = 'https://cdn.com/@foo/bar.js';
         const mockManifest = {
           '@foo/bar': {
-            file,
+            file: '',
             id: 0,
             name: '',
-            publicPath: '',
+            publicPath,
           },
         };
 
-        expect(lazyComponent.getBundleUrl(mockManifest)).toEqual(file);
+        expect(lazyComponent.getBundleUrl(mockManifest)).toEqual(publicPath);
       });
     });
   });

--- a/src/lazy/__tests__/lazy.test.tsx
+++ b/src/lazy/__tests__/lazy.test.tsx
@@ -1,15 +1,21 @@
+import React from 'react';
 import { lazyForPaint } from '..';
-import { isNodeEnvironment } from '../../utils';
+import { LazySuspense } from '../../suspense';
+import { isNodeEnvironment, tryRequire } from '../../utils';
+import { act, render } from '@testing-library/react';
+import { nextTick } from '../../__tests__/utils';
 
 jest.mock('../../utils', () => ({
   ...jest.requireActual('../../utils'),
   isNodeEnvironment: jest.fn(),
+  tryRequire: jest.fn(),
 }));
 
 describe('lazy', () => {
+  const mockModuleId = '@foo/bar';
   describe('LazyComponent', () => {
     (isNodeEnvironment as any).mockImplementation(() => true);
-    const mockModuleId = '@foo/bar';
+
     const lazyComponent = lazyForPaint(
       // @ts-ignore - mocking import()
       () => Promise.resolve({ default: mockModuleId }),
@@ -33,6 +39,35 @@ describe('lazy', () => {
 
         expect(lazyComponent.getBundleUrl(mockManifest)).toEqual(publicPath);
       });
+    });
+  });
+
+  describe('createComponentClient', () => {
+    (isNodeEnvironment as any).mockImplementation(() => false);
+    it('should handle named exports', async () => {
+      (tryRequire as any).mockImplementation(() => false);
+      const MockComponent = jest.fn(() => <div />);
+      const MockFallback = () => <div />;
+      const MyAsync = lazyForPaint(
+        // @ts-ignore - mocking import()
+        () => Promise.resolve({ MockComponent }).then(m => m.MockComponent),
+        {
+          getCacheId: () => '',
+          moduleId: mockModuleId,
+        }
+      );
+
+      await act(async () => {
+        render(
+          <LazySuspense fallback={<MockFallback />}>
+            <MyAsync />
+          </LazySuspense>
+        );
+
+        await nextTick();
+      });
+
+      expect(MockComponent).toHaveBeenCalled();
     });
   });
 });

--- a/src/lazy/components/client.tsx
+++ b/src/lazy/components/client.tsx
@@ -21,6 +21,7 @@ export const createComponentClient = ({
       isCached = true;
     });
   }
+
   const ResolvedLazy = React.lazy(() => deferred.promise);
 
   return (props: any) => {

--- a/src/lazy/components/server.tsx
+++ b/src/lazy/components/server.tsx
@@ -4,17 +4,11 @@ import { LazySuspenseContext } from '../../suspense/context';
 
 export const createComponentServer = ({
   ssr,
-  deferred,
+  loader,
   cacheId,
   dataLazyId,
 }: any) => (props: any) => {
-  if (ssr) {
-    deferred.start();
-  }
-
-  const Resolved = ssr
-    ? tryRequire(cacheId) || getExport(deferred.result)
-    : null;
+  const Resolved = ssr ? tryRequire(cacheId) || getExport(loader()) : null;
   const { fallback } = useContext(LazySuspenseContext);
 
   return (

--- a/src/lazy/components/server.tsx
+++ b/src/lazy/components/server.tsx
@@ -8,6 +8,10 @@ export const createComponentServer = ({
   cacheId,
   dataLazyId,
 }: any) => (props: any) => {
+  if (ssr) {
+    deferred.start();
+  }
+
   const Resolved = ssr
     ? tryRequire(cacheId) || getExport(deferred.result)
     : null;

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -76,19 +76,18 @@ const lazyProxy = (
   const isServer = isNodeEnvironment();
   const cacheId = getCacheId();
   const dataLazyId = hash(moduleId);
-  const deferred = createDeferred(loader);
 
   const LazyComponent: any = isServer
     ? createComponentServer({
         ssr,
-        deferred,
+        loader,
         cacheId,
         dataLazyId,
       })
     : createComponentClient({
         ssr,
         defer,
-        deferred,
+        deferred: createDeferred(loader),
         cacheId,
         dataLazyId,
       });

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -43,14 +43,21 @@ type LazyComponent = React.ComponentType & {
 
 const createDeferred = (loader: Loader) => {
   let resolve: any;
+  let result: any;
   const deferred = {
     promise: new Promise<ImportDefaultComponent>(r => {
       resolve = (m: any) => {
+        let withDefault;
         deferred.result = m;
-        r(m);
+
+        if (!m.default) {
+          withDefault = { default: m };
+        }
+
+        r(withDefault ? withDefault : m);
       };
     }),
-    result: undefined,
+    result,
     start: () => loader().then(resolve),
   };
 


### PR DESCRIPTION
### Fixed 

* The `deferred.start` function will now only be called in the server component on render 
* The `publicPath` rather than the `file` will now be returned from `LazyComponent.getBundleUrl`

### Changed

* Named exports now supported without needing to wrap the resolved imports in `{ default: MyComponent }`