### PR TITLE
Support loader error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ yarn.lock
 
 # misc
 local-scripts/
+.idea
 .vscode
 src/webpack/__tests__/__fixtures__/webpack/output

--- a/examples/basic/index.tsx
+++ b/examples/basic/index.tsx
@@ -37,36 +37,39 @@ function buildComponents() {
     });
   // force components reset faking server/client
   Async.ComponentWithSSR = lazyForPaint(() => import('./components/with-ssr'), {
-    id: () => (require as any).resolveWeak('./components/with-ssr'),
+    getCacheId: () => (require as any).resolveWeak('./components/with-ssr'),
   });
   Async.ComponentNoSSR = lazyForPaint(() => import('./components/no-ssr'), {
-    id: () => (require as any).resolveWeak('./components/no-ssr'),
+    getCacheId: () => (require as any).resolveWeak('./components/no-ssr'),
     ssr: false,
   });
   Async.ComponentDeferWithSSR = lazyAfterPaint(
     () => import('./components/defer-with-ssr'),
     {
-      id: () => (require as any).resolveWeak('./components/defer-with-ssr'),
+      getCacheId: () =>
+        (require as any).resolveWeak('./components/defer-with-ssr'),
     }
   );
   Async.ComponentDeferNoSSR = lazy(() => import('./components/defer-no-ssr'), {
-    id: () => (require as any).resolveWeak('./components/defer-no-ssr'),
+    getCacheId: () => (require as any).resolveWeak('./components/defer-no-ssr'),
   });
   Async.ComponentWaitWithSSR = lazyForPaint(
     () => import('./components/wait-with-ssr'),
     {
-      id: () => (require as any).resolveWeak('./components/wait-with-ssr'),
+      getCacheId: () =>
+        (require as any).resolveWeak('./components/wait-with-ssr'),
     }
   );
   Async.ComponentWaitNoSSR = lazyForPaint(
     () => import('./components/wait-no-ssr'),
     {
-      id: () => (require as any).resolveWeak('./components/wait-no-ssr'),
+      getCacheId: () =>
+        (require as any).resolveWeak('./components/wait-no-ssr'),
       ssr: false,
     }
   );
   Async.ComponentDynamic = lazyForPaint(() => import('./components/dynamic'), {
-    id: () => (require as any).resolveWeak('./components/dynamic'),
+    getCacheId: () => (require as any).resolveWeak('./components/dynamic'),
   });
 }
 

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { render, act } from '@testing-library/react';
 
@@ -32,7 +32,7 @@ const createApp = ({
   (isNodeEnvironment as any).mockImplementation(() => server);
 
   const Child = jest.fn(() => <p className="p">Content</p>);
-  const Fallback = jest.fn(() => <i>Fallback</i>) as any;
+  const Fallback = jest.fn<any, void[]>(() => <i>Fallback</i>);
   const { mockImport, resolveImport } = createMockImport(Child, ssr && server);
   const lazyFn = phase === PHASE.AFTER_PAINT ? lazyAfterPaint : lazyForPaint;
   // @ts-ignore - We are mocking the import
@@ -197,7 +197,13 @@ describe('render without priority', () => {
 });
 
 describe('with static phase', () => {
-  const Wrapper = ({ children, phase }: any) => {
+  const Wrapper = ({
+    children,
+    phase,
+  }: {
+    children: ReactElement;
+    phase?: number;
+  }) => {
     const { startNextPhase } = useLazyPhase();
     useEffect(() => {
       if (phase === PHASE.AFTER_PAINT) startNextPhase();

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -3,7 +3,7 @@ export const createMockImport = (
   sync: boolean
 ) => {
   const resolved = { default: component };
-  let resolve: any;
+  let resolve: (value: typeof resolved) => void;
   let mockImport;
 
   if (sync) {
@@ -12,18 +12,16 @@ export const createMockImport = (
 
     mockImport = { ...resolved, then };
   } else {
-    mockImport = new Promise(r => {
-      resolve = r;
+    mockImport = new Promise<typeof resolved>(res => {
+      resolve = res;
     });
   }
 
   const resolveImport = async () => {
     resolve(resolved);
 
-    // let react re-render
+    // Let react re-render
     await nextTick();
-
-    return undefined;
   };
 
   return { mockImport, resolveImport };

--- a/src/collect/hydrate.ts
+++ b/src/collect/hydrate.ts
@@ -1,6 +1,9 @@
-export const refElements = (fromEl: any, id: string) => {
+export const refElements = (
+  fromEl: HTMLInputElement,
+  id: string | undefined
+) => {
   const result = [];
-  let el = fromEl;
+  let el: (ChildNode & { readonly dataset?: DOMStringMap }) | null = fromEl;
   while ((el = el.nextSibling)) {
     if (el.dataset && el.dataset.lazyEnd === id) break;
     result.push(el);

--- a/src/collect/index.ts
+++ b/src/collect/index.ts
@@ -3,9 +3,11 @@ import { cloneElements } from './render';
 import { refElements } from './hydrate';
 
 export const collect = () => {
-  const markers = document.querySelectorAll('input[data-lazy-begin]');
+  const markers = document.querySelectorAll<HTMLInputElement>(
+    'input[data-lazy-begin]'
+  );
   for (let i = 0, j = markers.length; i < j; i += 1) {
-    const el = markers[i] as any;
+    const el = markers[i];
     const { lazyBegin } = el.dataset || {};
     const value =
       SETTINGS.CURRENT_MODE === MODE.RENDER

--- a/src/collect/render.ts
+++ b/src/collect/render.ts
@@ -1,6 +1,9 @@
-export const cloneElements = (fromEl: any, id: string) => {
+export const cloneElements = (
+  fromEl: HTMLInputElement,
+  id: string | undefined
+) => {
   const fragment = document.createElement('div');
-  let el = fromEl;
+  let el: (ChildNode & { readonly dataset?: DOMStringMap }) | null = fromEl;
   while ((el = el.nextSibling)) {
     if (el.dataset && el.dataset.lazyEnd === id) break;
     // cloneNode is 50% faster than outerHTML/textContent

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,15 @@
 export { MODE, SETTINGS } from './constants';
 export { LooselyLazy as default } from './init';
-export { lazyForPaint, lazyAfterPaint, lazy } from './lazy';
-export { LazySuspense } from './suspense';
+export {
+  ClientLoader,
+  LoaderError,
+  isLoaderError,
+  lazyForPaint,
+  lazyAfterPaint,
+  lazy,
+  Options as LazyOptions,
+  Loader,
+  ServerLoader,
+} from './lazy';
+export { Fallback, LazySuspense, LazySuspenseProps } from './suspense';
 export { LazyWait, useLazyPhase } from './phase';

--- a/src/lazy/__tests__/loader-error.test.ts
+++ b/src/lazy/__tests__/loader-error.test.ts
@@ -1,0 +1,39 @@
+import { LoaderError, isLoaderError } from '../errors/loader-error';
+
+describe('LoaderError', () => {
+  it('returns an error object that contains the correct name, message, native error, and stack', () => {
+    const error = new Error('Error');
+    const loaderError = new LoaderError('foo', error);
+
+    expect(loaderError).toMatchObject({
+      message: 'Failed to load module foo',
+      name: 'LoaderError',
+      nativeError: error,
+    });
+    expect(loaderError.stack).toMatch(
+      /^LoaderError: Failed to load module foo/
+    );
+  });
+});
+
+describe('isLoaderError', () => {
+  it('returns true when given an error of type LoaderError', () => {
+    const loaderError = new LoaderError('foo', new Error(''));
+    expect(isLoaderError(loaderError)).toBe(true);
+  });
+
+  it('returns false when given an error of type Error', () => {
+    const error = new Error('');
+    expect(isLoaderError(error)).toBe(false);
+  });
+
+  it('returns false when given an error of type TypeError', () => {
+    const error = new TypeError("Cannot read property 'foo' of null");
+    expect(isLoaderError(error)).toBe(false);
+  });
+
+  it('returns false when given an error of type SyntaxError', () => {
+    const error = new SyntaxError('Unexpected identifier');
+    expect(isLoaderError(error)).toBe(false);
+  });
+});

--- a/src/lazy/__tests__/utils.ts
+++ b/src/lazy/__tests__/utils.ts
@@ -1,0 +1,25 @@
+import { Component, ReactNode } from 'react';
+
+export class ErrorBoundary extends Component<
+  { fallback: ReactNode; onError: (error: Error) => void },
+  { error: Error | void }
+> {
+  state = {
+    error: undefined,
+  };
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error);
+    this.setState({ error });
+  }
+
+  render() {
+    const { children, fallback } = this.props;
+    const { error } = this.state;
+    if (!error) {
+      return children;
+    }
+
+    return fallback;
+  }
+}

--- a/src/lazy/components/client.tsx
+++ b/src/lazy/components/client.tsx
@@ -1,9 +1,11 @@
-import React, { useContext, useMemo, useEffect } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 
 import { COLLECTED, SETTINGS, MODE } from '../../constants';
 import { LazySuspenseContext } from '../../suspense';
 import { usePhaseSubscription } from '../../phase';
 import { tryRequire } from '../../utils';
+import { Deferred } from '../deferred';
+import { LoaderError } from '../errors/loader-error';
 import { PlaceholderFallbackRender } from '../placeholders/render';
 import { PlaceholderFallbackHydrate } from '../placeholders/hydrate';
 
@@ -13,7 +15,13 @@ export const createComponentClient = ({
   deferred,
   dataLazyId,
   ssr,
-}: any) => {
+}: {
+  cacheId: string;
+  defer: number;
+  deferred: Deferred;
+  dataLazyId: string;
+  ssr: boolean;
+}) => {
   let isCached = Boolean(tryRequire(cacheId));
 
   if (!isCached) {
@@ -30,10 +38,20 @@ export const createComponentClient = ({
     }
 
     const { setFallback } = useContext(LazySuspenseContext);
+    const [, setState] = useState();
     const isOwnPhase = usePhaseSubscription(defer);
 
     useMemo(() => {
-      if (isOwnPhase) deferred.start().then(() => setFallback(null));
+      if (isOwnPhase)
+        deferred
+          .start()
+          .then(() => setFallback(null))
+          .catch((err: Error) => {
+            // Throw the error within the component lifecycle -- refer to https://github.com/facebook/react/issues/11409
+            setState(() => {
+              throw new LoaderError(cacheId, err);
+            });
+          });
     }, [isOwnPhase, setFallback]);
 
     useMemo(() => {

--- a/src/lazy/components/server.tsx
+++ b/src/lazy/components/server.tsx
@@ -1,14 +1,32 @@
 import React, { useContext } from 'react';
+import { LazySuspenseContext } from '../../suspense';
 import { tryRequire, getExport } from '../../utils';
-import { LazySuspenseContext } from '../../suspense/context';
+import { LoaderError } from '../errors/loader-error';
+import { ServerLoader } from '../loader';
+
+const load = (cacheId: string, loader: ServerLoader) => {
+  let result;
+  try {
+    result = loader();
+  } catch (err) {
+    throw new LoaderError(cacheId, err);
+  }
+
+  return getExport(result);
+};
 
 export const createComponentServer = ({
-  ssr,
-  loader,
   cacheId,
   dataLazyId,
-}: any) => (props: any) => {
-  const Resolved = ssr ? tryRequire(cacheId) || getExport(loader()) : null;
+  loader,
+  ssr,
+}: {
+  cacheId: string;
+  dataLazyId: string;
+  loader: ServerLoader;
+  ssr: boolean;
+}) => (props: any) => {
+  const Resolved = ssr ? tryRequire(cacheId) || load(cacheId, loader) : null;
   const { fallback } = useContext(LazySuspenseContext);
 
   return (

--- a/src/lazy/deferred.ts
+++ b/src/lazy/deferred.ts
@@ -1,0 +1,30 @@
+import { ImportDefaultComponent, ClientLoader } from './loader';
+
+export type Deferred = {
+  promise: Promise<ImportDefaultComponent>;
+  result: ImportDefaultComponent | void;
+  start(): Promise<void>;
+};
+
+export const createDeferred = (loader: ClientLoader): Deferred => {
+  let resolve: (m: any) => void;
+
+  const deferred = {
+    promise: new Promise<ImportDefaultComponent>(res => {
+      resolve = (m: any) => {
+        let withDefault;
+        deferred.result = m;
+
+        if (!m.default) {
+          withDefault = { default: m };
+        }
+
+        res(withDefault ? withDefault : m);
+      };
+    }),
+    result: undefined,
+    start: () => loader().then(resolve),
+  };
+
+  return deferred;
+};

--- a/src/lazy/errors/loader-error.ts
+++ b/src/lazy/errors/loader-error.ts
@@ -1,0 +1,16 @@
+export class LoaderError extends Error {
+  public readonly nativeError: Error;
+
+  constructor(id: string, error: Error) {
+    super();
+    this.message = `Failed to load module ${id}`;
+    this.name = 'LoaderError';
+    this.nativeError = error;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LoaderError);
+    }
+  }
+}
+
+export const isLoaderError = (error: Error) => error instanceof LoaderError;

--- a/src/lazy/loader.ts
+++ b/src/lazy/loader.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export type ImportDefaultComponent = {
+  default: React.ComponentType<any>;
+};
+
+export type Loader = ClientLoader | ServerLoader;
+
+export type ClientLoader = () => Promise<ImportDefaultComponent>;
+
+export type ServerLoader = () => ImportDefaultComponent;

--- a/src/lazy/placeholders/hydrate.tsx
+++ b/src/lazy/placeholders/hydrate.tsx
@@ -1,6 +1,14 @@
 import React, { Fragment } from 'react';
 
-export const PlaceholderFallbackHydrate = ({ id, content }: any) => {
+export type PlaceholderFallbackHydrateProps = {
+  id: string;
+  content: HTMLElement[];
+};
+
+export const PlaceholderFallbackHydrate = ({
+  id,
+  content,
+}: PlaceholderFallbackHydrateProps) => {
   return (
     <>
       <input type="hidden" data-lazy-begin={id} />

--- a/src/lazy/placeholders/render.tsx
+++ b/src/lazy/placeholders/render.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useLayoutEffect } from 'react';
 
-const usePlaceholderRender = (resolveId: string, content: any) => {
+const usePlaceholderRender = (resolveId: string, content: HTMLElement[]) => {
   const hydrationRef = useRef<HTMLInputElement | null>(null);
   const { current: ssrDomNodes } = useRef(content || ([] as HTMLElement[]));
 
@@ -11,13 +11,15 @@ const usePlaceholderRender = (resolveId: string, content: any) => {
     if (parentNode && !parentNode.contains(ssrDomNodes[0])) {
       ssrDomNodes
         .reverse()
-        .forEach((node: any) =>
+        .forEach((node: HTMLElement) =>
           parentNode.insertBefore(node, (element as any).nextSibling)
         );
     }
 
     return () => {
-      ssrDomNodes.forEach((node: any) => node.parentNode.removeChild(node));
+      ssrDomNodes.forEach((node: HTMLElement) =>
+        node.parentNode?.removeChild(node)
+      );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hydrationRef.current, ssrDomNodes]);
@@ -25,7 +27,15 @@ const usePlaceholderRender = (resolveId: string, content: any) => {
   return hydrationRef;
 };
 
-export const PlaceholderFallbackRender = ({ id, content }: any) => {
+export type PlaceholderFallbackRenderProps = {
+  id: string;
+  content: HTMLElement[];
+};
+
+export const PlaceholderFallbackRender = ({
+  id,
+  content,
+}: PlaceholderFallbackRenderProps) => {
   const placeholderRef = usePlaceholderRender(id, content);
 
   return <input type="hidden" data-lazy-begin={id} ref={placeholderRef} />;

--- a/src/phase/component.tsx
+++ b/src/phase/component.tsx
@@ -1,24 +1,28 @@
-import React, { useContext, useMemo, useRef } from 'react';
+import React, { ReactNode, useContext, useMemo, useRef } from 'react';
 
 import { PHASE } from '../constants';
 import { LazyPhaseContext } from './context';
+import { Listener } from './listeners';
 import { createSubscribe } from './utils';
 
 type LazyWaitProps = {
   until: boolean;
-  children: any;
+  children: ReactNode;
 };
+
 export const LazyWait = ({ until, children }: LazyWaitProps) => {
   const { api: ctxApi } = useContext(LazyPhaseContext);
   const phaseRef = useRef(-1);
 
   phaseRef.current = until ? PHASE.LAZY : -1;
 
-  // notify all children of phase change
-  const { current: listeners } = useRef<any>([]);
+  // Notify all children of phase change
+  const { current: listeners } = useRef<Listener[]>([]);
 
   useMemo(() => {
-    listeners.slice(0).forEach((listener: any) => listener(phaseRef.current));
+    listeners.slice(0).forEach((listener: Listener) => {
+      listener(phaseRef.current);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listeners, phaseRef.current]);
 

--- a/src/phase/context.tsx
+++ b/src/phase/context.tsx
@@ -1,14 +1,14 @@
 import { createContext, useContext } from 'react';
 
 import { PHASE, PHASE_LAZY_DELAY } from '../constants';
+import { Listener, LISTENERS } from './listeners';
 import { createSubscribe } from './utils';
 
-export const LISTENERS: any[] = [];
 let CURRENT_PHASE = PHASE.PAINT;
 
-export const setCurrent = (value: number) => {
-  CURRENT_PHASE = value;
-  LISTENERS.slice(0).forEach((listener: any) => listener(value));
+export const setCurrent = (phase: number) => {
+  CURRENT_PHASE = phase;
+  LISTENERS.slice(0).forEach((listener: Listener) => listener(phase));
 };
 
 export const LazyPhaseContext = createContext({

--- a/src/phase/index.tsx
+++ b/src/phase/index.tsx
@@ -1,8 +1,4 @@
 export { LazyWait } from './component';
-export {
-  useLazyPhase,
-  LazyPhaseContext,
-  setCurrent,
-  LISTENERS,
-} from './context';
+export { useLazyPhase, LazyPhaseContext, setCurrent } from './context';
 export { usePhaseSubscription } from './controller';
+export { LISTENERS } from './listeners';

--- a/src/phase/listeners.ts
+++ b/src/phase/listeners.ts
@@ -1,0 +1,3 @@
+export type Listener = (phase: number) => void;
+
+export const LISTENERS: Listener[] = [];

--- a/src/phase/utils.tsx
+++ b/src/phase/utils.tsx
@@ -1,4 +1,8 @@
-export const createSubscribe = (listeners: any[]) => (listener: any) => {
+import { Listener } from './listeners';
+
+export const createSubscribe = (listeners: Listener[]) => (
+  listener: Listener
+) => {
   listeners.push(listener);
 
   return () => {

--- a/src/suspense/context.tsx
+++ b/src/suspense/context.tsx
@@ -1,9 +1,16 @@
-import React, { Fragment, createContext } from 'react';
+import React, { Fragment, createContext, SuspenseProps } from 'react';
 
-export const LazySuspenseContext = createContext({
+export type Fallback = SuspenseProps['fallback'];
+
+export type LazySuspenseContextType = {
+  fallback: Fallback;
+  setFallback(fallback: Fallback): void;
+};
+
+export const LazySuspenseContext = createContext<LazySuspenseContextType>({
   fallback: <Fragment />,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setFallback: (f: any) => {
+  setFallback: (fallback: Fallback) => {
     console.warn('Missing <LooselySuspense /> boundary');
   },
 });

--- a/src/suspense/index.tsx
+++ b/src/suspense/index.tsx
@@ -1,2 +1,2 @@
-export { LazySuspense } from './component';
-export { LazySuspenseContext } from './context';
+export { LazySuspense, LazySuspenseProps } from './component';
+export { Fallback, LazySuspenseContext } from './context';

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -1,5 +1,5 @@
 import url from 'url';
-import { Compiler, compilation as webpackCompilation, Module } from 'webpack';
+import { Compiler, compilation as webpackCompilation } from 'webpack';
 
 type Compilation = webpackCompilation.Compilation;
 


### PR DESCRIPTION
Currently when the loader (i.e. usually an `import()` function) fails to request or execute the resource in the client, it will result in either an uncaught or lost exception, and thus cannot be caught in a React error boundary. This occurs because the loader is triggered within a `useMemo` hook, and this is considered to be outside of the React component lifecycle. Additionally, when these errors are thrown we have no way of distinguishing whether they occurred due to a loader failure or after the resource is loaded as a result of bootstrap or user interaction.

These changes aim to solve this problem by:
1. Throwing the error within the React component lifecycle
2. Wrapping the error in a custom `LoaderError` object so that we can distinguish where it came from

## Changes
* Create a `LoaderError` error type and `isLoaderError` function for consumers
    * The `LoaderError` exposes the internal error object as `nativeError`, which replicates the `SyntheticEvent#nativeEvent` API (see https://reactjs.org/docs/events.html) to offer the most flexibility
* Throw client error within `setState` so that it is within the component lifecycle
* Wrap the client and server errors with the `LoaderError`
* Add tests for `LoaderError`, `isLoaderError`, and the error handling within client and server components
    * Silencing the console is required when throwing the error within `jest` and `@testing-library/react`
* Remove several `any` types from the codebase
    * The most substantial change from this is needing to wrap the `Suspense#DynamicFallback` component in fragments
    * Extracted types into separate files to prevent circular dependencies, often between the main and context files
* Expose the new errors and more types in the entry point

