### PR TITLE
Added modulePathReplacer option to babel plugin

### DIFF
--- a/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/code.js
+++ b/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/code.js
@@ -1,0 +1,5 @@
+import { lazyForPaint } from 'react-loosely-lazy';
+
+const RelativeFileImportWithBasePath = lazyForPaint(() =>
+  import('./__mocks__/imports/base-path-component')
+);

--- a/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/options.json
+++ b/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/options.json
@@ -1,0 +1,6 @@
+{
+  "modulePathReplacer": {
+    "from": "./../../../src",
+    "to": "./src"
+  }
+}

--- a/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/output.js
+++ b/src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/output.js
@@ -1,0 +1,22 @@
+import { lazyForPaint } from 'react-loosely-lazy';
+const RelativeFileImportWithBasePath = lazyForPaint(
+  () => {
+    const resolved = require('./__mocks__/imports/base-path-component');
+
+    const then = fn => fn(resolved);
+
+    return { ...resolved, then };
+  },
+  {
+    ssr: true,
+    getCacheId: function () {
+      if (require && require.resolveWeak) {
+        return require.resolveWeak('./__mocks__/imports/base-path-component');
+      }
+
+      return './__mocks__/imports/base-path-component';
+    },
+    moduleId:
+      './src/babel/__tests__/__fixtures__/babel/relative-file-import-with-base-path/__mocks__/imports/base-path-component.js',
+  }
+);

--- a/src/babel/__tests__/__fixtures__/babel/with-client-option/code.js
+++ b/src/babel/__tests__/__fixtures__/babel/with-client-option/code.js
@@ -1,0 +1,5 @@
+import { lazyForPaint } from 'react-loosely-lazy';
+
+const WithClientOption = lazyForPaint(() => import('react'), {
+  ssr: true,
+});

--- a/src/babel/__tests__/__fixtures__/babel/with-client-option/options.json
+++ b/src/babel/__tests__/__fixtures__/babel/with-client-option/options.json
@@ -1,0 +1,3 @@
+{
+  "client": true
+}

--- a/src/babel/__tests__/__fixtures__/babel/with-client-option/output.js
+++ b/src/babel/__tests__/__fixtures__/babel/with-client-option/output.js
@@ -1,0 +1,12 @@
+import { lazyForPaint } from 'react-loosely-lazy';
+const WithClientOption = lazyForPaint(() => import('react'), {
+  ssr: true,
+  getCacheId: function () {
+    if (require && require.resolveWeak) {
+      return require.resolveWeak('react');
+    }
+
+    return 'react';
+  },
+  moduleId: './node_modules/react/index.js',
+});

--- a/src/babel/index.ts
+++ b/src/babel/index.ts
@@ -52,6 +52,8 @@ function withModuleExtension(filePath: string): string {
  *
  * @param importSpecifier - The import string as it is written in application source code
  * @param filename - The absolute path to the file being transpiled
+ * @param modulePathReplacer - Contains from and to string keys to override a specific part of the resulting
+ * module paths generated
  */
 function getModulePath(
   importSpecifier: string,


### PR DESCRIPTION
### Added 

* `modulePathReplacer` option to the babel plugin which will try to replace the final module path string with what the consumer needs. This is useful for situations where a manifest file is used in a different process but paths need to be kept relative to the webpack plugin's location
