### PR TITLE
Remove support for internal caching resolution

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,5 @@
 import { format } from 'util';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 const error = console.error;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2580,9 +2580,9 @@
       }
     },
     "@testing-library/jest-dom": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.7.0.tgz",
-      "integrity": "sha512-ZV0OtBXmTDEDxrIbqJXiOcXCZ6aIMpmDlmfHj0hGNsSuQ/nX0qPAs9HWmCzXvPfTrhufTiH2nJLvDJu/LgHzwQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.8.0.tgz",
+      "integrity": "sha512-9Y4FxYIxfwHpUyJVqI8EOfDP2LlEBqKwXE3F+V8ightji0M2rzQB+9kqZ5UJxNs+9oXJIgvYj7T3QaXLNHVDMw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
@@ -2944,9 +2944,9 @@
       }
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.6.0.tgz",
-      "integrity": "sha512-VRl4kIzvtySjscCpMul3mz0UgEd40nG/jWluaXIYi5UG8cOOLD56u8IIgHZk+gSKmccRCsVv7AAg1HBmE7OQ2w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.7.0.tgz",
+      "integrity": "sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
@@ -9963,18 +9963,6 @@
         "pretty-format": "^25.5.0"
       },
       "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -10015,18 +10003,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
         },
         "supports-color": {
           "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.6",
-    "@testing-library/jest-dom": "^5.7.0",
+    "@testing-library/jest-dom": "^5.8.0",
     "@testing-library/react": "^10.0.4",
     "@types/jest": "^25.2.2",
     "@types/react": "^16.9.35",

--- a/src/lazy/components/client.tsx
+++ b/src/lazy/components/client.tsx
@@ -3,7 +3,6 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { COLLECTED, SETTINGS, MODE } from '../../constants';
 import { LazySuspenseContext } from '../../suspense';
 import { usePhaseSubscription } from '../../phase';
-import { tryRequire } from '../../utils';
 import { Deferred } from '../deferred';
 import { LoaderError } from '../errors/loader-error';
 import { PlaceholderFallbackRender } from '../placeholders/render';
@@ -22,21 +21,9 @@ export const createComponentClient = ({
   dataLazyId: string;
   ssr: boolean;
 }) => {
-  let isCached = Boolean(tryRequire(cacheId));
-
-  if (!isCached) {
-    deferred.promise.then(() => {
-      isCached = true;
-    });
-  }
-
   const ResolvedLazy = React.lazy(() => deferred.promise);
 
   return (props: any) => {
-    if (isCached) {
-      return <ResolvedLazy {...props} />;
-    }
-
     const { setFallback } = useContext(LazySuspenseContext);
     const [, setState] = useState();
     const isOwnPhase = usePhaseSubscription(defer);

--- a/src/lazy/components/server.tsx
+++ b/src/lazy/components/server.tsx
@@ -1,18 +1,15 @@
 import React, { useContext } from 'react';
 import { LazySuspenseContext } from '../../suspense';
-import { tryRequire, getExport } from '../../utils';
 import { LoaderError } from '../errors/loader-error';
+import { getExport } from '../../utils';
 import { ServerLoader } from '../loader';
 
 const load = (cacheId: string, loader: ServerLoader) => {
-  let result;
   try {
-    result = loader();
+    return getExport(loader());
   } catch (err) {
     throw new LoaderError(cacheId, err);
   }
-
-  return getExport(result);
 };
 
 export const createComponentServer = ({
@@ -26,7 +23,7 @@ export const createComponentServer = ({
   loader: ServerLoader;
   ssr: boolean;
 }) => (props: any) => {
-  const Resolved = ssr ? tryRequire(cacheId) || load(cacheId, loader) : null;
+  const Resolved = ssr ? load(cacheId, loader) : null;
   const { fallback } = useContext(LazySuspenseContext);
 
   return (

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -1,12 +1,7 @@
-import React, { ComponentType } from 'react';
+import React from 'react';
 import { PHASE } from '../constants';
 
-import {
-  hash,
-  tryRequire,
-  displayNameFromId,
-  isNodeEnvironment,
-} from '../utils';
+import { hash, displayNameFromId, isNodeEnvironment } from '../utils';
 import { createComponentServer } from './components/server';
 import { createComponentClient } from './components/client';
 import { createDeferred } from './deferred';
@@ -74,10 +69,6 @@ const lazyProxy = (
    * without having to load the manifest on the client as it could be huge.
    */
   LazyComponent.preload = () => {
-    if (tryRequire(cacheId)) {
-      return;
-    }
-
     const head = document.querySelector('head');
 
     if (!head) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,25 +1,8 @@
 /* eslint-disable @typescript-eslint/camelcase */
-declare const __webpack_require__: (id: string) => any;
-declare const __webpack_modules__: { [key: string]: any };
 
 export { default as hash } from './hash';
 
 export const getExport = (m: any) => ('default' in m ? m.default : m);
-
-export const tryRequire = (id: string) => {
-  if (
-    typeof __webpack_require__ === 'function' &&
-    typeof __webpack_modules__ === 'object' &&
-    __webpack_modules__[id]
-  ) {
-    try {
-      return getExport(__webpack_require__(id));
-      // eslint-disable-next-line no-empty
-    } catch {}
-  }
-
-  return null;
-};
 
 export const displayNameFromId = (id: string) => {
   const fName = id.split('/').slice(-3).join('/');


### PR DESCRIPTION
These changes remove `tryRequire` and all of its usages as it results in two bugs:

1. A given lazy component may never be loaded in the client when the module is already cached by webpack, since the deferred promise is never started.
2. `tryRequire` always returns the default export, and thus does not work correctly when returning a named export in the loader.

In addition to removing support for this feature, the lazy tests have been refactored to use the `@testing-library/react` wait utilities to ensure there are no race conditions and thus flakey tests.