### PR TITLE
Remove webpack plugin deprecated API usage

### DIFF
--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -74,21 +74,24 @@ export class ReactLooselyLazyPlugin {
   }
 
   apply(compiler: Compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
-      const manifest = buildManifest(compiler, compilation);
-      const json = JSON.stringify(manifest, null, 2);
+    compiler.hooks.emit.tapAsync(
+      ReactLooselyLazyPlugin.name,
+      (compilation, callback) => {
+        const manifest = buildManifest(compiler, compilation);
+        const json = JSON.stringify(manifest, null, 2);
 
-      compilation.assets[this.filename] = {
-        source() {
-          return json;
-        },
-        size() {
-          return json.length;
-        },
-      };
+        compilation.assets[this.filename] = {
+          source() {
+            return json;
+          },
+          size() {
+            return json.length;
+          },
+        };
 
-      callback();
-    });
+        callback();
+      }
+    );
   }
 }
 


### PR DESCRIPTION
These changes replace the deprecated `compiler.plugin('emit'` usage with `compiler.hooks.emit.tapAsync` so that the webpack tests do not log a deprecation warning.