### PR TITLE
Fix type re-export warning in webpack 5 (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .local
 .vscode
+.history
 
 coverage
 node_modules

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,17 +10,12 @@ export {
   LoaderError,
 } from './lazy';
 
-export {
-  ClientLoader,
-  Loader,
-  LazyOptions,
-  ServerLoader,
-  LazyComponent,
-} from './lazy';
+export type { ClientLoader, Loader, ServerLoader } from './lazy';
+export type { LazyOptions, LazyComponent } from './lazy';
 
 export { LazySuspense } from './suspense';
-export { Fallback, LazySuspenseProps } from './suspense';
+export type { Fallback, LazySuspenseProps } from './suspense';
 
 export { LazyWait, useLazyPhase } from './phase';
-export { LazyWaitProps } from './phase';
-export { Settings } from './types';
+export type { LazyWaitProps } from './phase';
+export type { Settings } from './types';

--- a/src/lazy/__tests__/lazy.typescript.test.tsx
+++ b/src/lazy/__tests__/lazy.typescript.test.tsx
@@ -2,8 +2,8 @@ import React, { ComponentType } from 'react';
 import { lazyForPaint, PRIORITY } from 'react-loosely-lazy';
 import { FooProps } from './__fixtures__/foo';
 
-const UntypedEmptyPropsTestComponent = lazyForPaint(() =>
-  import('./__fixtures__/empty-props')
+const UntypedEmptyPropsTestComponent = lazyForPaint(
+  () => import('./__fixtures__/empty-props')
 );
 
 <UntypedEmptyPropsTestComponent />;
@@ -12,8 +12,8 @@ const UntypedEmptyPropsTestComponent = lazyForPaint(() =>
 <UntypedEmptyPropsTestComponent foo="foo" />;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-const TypedEmptyPropsTestComponent = lazyForPaint<ComponentType<{}>>(() =>
-  import('./__fixtures__/empty-props')
+const TypedEmptyPropsTestComponent = lazyForPaint<ComponentType<{}>>(
+  () => import('./__fixtures__/empty-props')
 );
 
 <TypedEmptyPropsTestComponent />;
@@ -40,8 +40,8 @@ const NamedTypedEmptyPropsTestComponent = lazyForPaint<ComponentType<{}>>(() =>
 // @ts-expect-error foo prop is not allowed
 <NamedTypedEmptyPropsTestComponent foo="foo" />;
 
-const UntypedPropsTestComponent = lazyForPaint(() =>
-  import('./__fixtures__/foo')
+const UntypedPropsTestComponent = lazyForPaint(
+  () => import('./__fixtures__/foo')
 );
 
 // @ts-expect-error foo prop is missing
@@ -52,8 +52,8 @@ const UntypedPropsTestComponent = lazyForPaint(() =>
 // @ts-expect-error bar prop is not allowed
 <UntypedPropsTestComponent foo="foo" bar="bar" />;
 
-const TypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(() =>
-  import('./__fixtures__/foo')
+const TypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(
+  () => import('./__fixtures__/foo')
 );
 
 // @ts-expect-error foo prop is missing
@@ -88,9 +88,10 @@ const NamedTypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(() =>
 // @ts-expect-error bar prop is not allowed
 <NamedTypedPropsTestComponent foo="foo" bar="bar" />;
 
-const MixedTypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(() =>
-  // @ts-expect-error FooProps and BarProps do not match
-  import('./__fixtures__/bar')
+const MixedTypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(
+  () =>
+    // @ts-expect-error FooProps and BarProps do not match
+    import('./__fixtures__/bar')
 );
 
 const NamedMixedTypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(
@@ -99,8 +100,8 @@ const NamedMixedTypedPropsTestComponent = lazyForPaint<ComponentType<FooProps>>(
     import('./__fixtures__/bar').then(({ Bar }) => Bar)
 );
 
-const TestComponent = lazyForPaint<ComponentType<FooProps>>(() =>
-  import('./__fixtures__/foo')
+const TestComponent = lazyForPaint<ComponentType<FooProps>>(
+  () => import('./__fixtures__/foo')
 );
 
 TestComponent.getAssetUrls();

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -12,7 +12,8 @@ import { ClientLoader, Loader, ServerLoader } from './loader';
 import { preloadAsset } from './preload';
 import { LazyOptions, LazyComponent } from './types';
 
-export { Asset, Manifest, LazyOptions, LazyComponent };
+export type { Asset, Manifest };
+export type { LazyOptions, LazyComponent };
 
 function lazyProxy<C extends ComponentType<any>>(
   loader: Loader<C>,
@@ -103,5 +104,5 @@ export function lazy<C extends ComponentType<any>>(
   });
 }
 
-export { ClientLoader, Loader, ServerLoader };
+export type { ClientLoader, Loader, ServerLoader };
 export { LoaderError, isLoaderError } from './errors/loader-error';

--- a/src/phase/index.tsx
+++ b/src/phase/index.tsx
@@ -2,4 +2,4 @@ export { LazyWait } from './component';
 export { useLazyPhase, LazyPhaseContext, setCurrent } from './context';
 export { usePhaseSubscription } from './controller';
 export { LISTENERS } from './listeners';
-export { LazyWaitProps } from './types';
+export type { LazyWaitProps } from './types';

--- a/src/suspense/index.tsx
+++ b/src/suspense/index.tsx
@@ -1,3 +1,7 @@
 export { LazySuspense } from './component';
 export { LazySuspenseContext } from './context';
-export { Fallback, LazySuspenseContextType, LazySuspenseProps } from './types';
+export type {
+  Fallback,
+  LazySuspenseContextType,
+  LazySuspenseProps,
+} from './types';

--- a/src/webpack/__tests__/__fixtures__/app/index.tsx
+++ b/src/webpack/__tests__/__fixtures__/app/index.tsx
@@ -9,53 +9,62 @@ import { LazyProxy } from './ui/proxy/lazy';
 import { Static } from './ui/static';
 import './styles.css';
 
-const LazyForPaint = lazyForPaint(() =>
-  import(/* webpackChunkName: "async-lazy-for-paint" */ './ui/lazy-for-paint')
+const LazyForPaint = lazyForPaint(
+  () =>
+    import(/* webpackChunkName: "async-lazy-for-paint" */ './ui/lazy-for-paint')
 );
 
-const LazyAfterPaintAlias = lazyAfterPaintAlias(() =>
-  import(
-    /* webpackChunkName: "async-lazy-after-paint" */ './ui/lazy-after-paint'
-  )
+const LazyAfterPaintAlias = lazyAfterPaintAlias(
+  () =>
+    import(
+      /* webpackChunkName: "async-lazy-after-paint" */ './ui/lazy-after-paint'
+    )
 );
 
-const LazyAlias = lazyAlias(() =>
-  import(/* webpackChunkName: "async-lazy" */ './ui/lazy')
+const LazyAlias = lazyAlias(
+  () => import(/* webpackChunkName: "async-lazy" */ './ui/lazy')
 );
 
-const ReactLazy = lazy(() =>
-  import(/* webpackChunkName: "async-react-lazy" */ './ui/react-lazy')
+const ReactLazy = lazy(
+  () => import(/* webpackChunkName: "async-react-lazy" */ './ui/react-lazy')
 );
 
-const LazyConcatenatedModule = lazyForPaint(() =>
-  import(
-    /* webpackChunkName: "async-concatenated-module" */ './ui/concatenated-module'
-  )
+const LazyConcatenatedModule = lazyForPaint(
+  () =>
+    import(
+      /* webpackChunkName: "async-concatenated-module" */ './ui/concatenated-module'
+    )
 );
 
-const LazyExternalAssets = lazyForPaint(() =>
-  import(/* webpackChunkName: "async-external-assets" */ './ui/external-assets')
+const LazyExternalAssets = lazyForPaint(
+  () =>
+    import(
+      /* webpackChunkName: "async-external-assets" */ './ui/external-assets'
+    )
 );
 
-const LazyMultipleUsagesOne = lazyForPaint(() =>
-  import(
-    /* webpackChunkName: "async-multiple-usages-one" */ './ui/multiple-usages'
-  )
+const LazyMultipleUsagesOne = lazyForPaint(
+  () =>
+    import(
+      /* webpackChunkName: "async-multiple-usages-one" */ './ui/multiple-usages'
+    )
 );
 
-const LazyMultipleUsagesTwo = lazyForPaint(() =>
-  import(
-    /* webpackChunkName: "async-multiple-usages-two" */ './ui/multiple-usages'
-  )
+const LazyMultipleUsagesTwo = lazyForPaint(
+  () =>
+    import(
+      /* webpackChunkName: "async-multiple-usages-two" */ './ui/multiple-usages'
+    )
 );
 
-const LazyNested = lazyForPaint(() =>
-  import(/* webpackChunkName: "async-nested-lazy" */ './ui/nested-lazy')
+const LazyNested = lazyForPaint(
+  () => import(/* webpackChunkName: "async-nested-lazy" */ './ui/nested-lazy')
 );
 
-const LazyCustomAlias = lazyForPaint(() =>
-  // @ts-ignore This is a defined webpack alias
-  import(/* webpackChunkName: "async-custom-alias" */ 'custom-alias')
+const LazyCustomAlias = lazyForPaint(
+  () =>
+    // @ts-ignore This is a defined webpack alias
+    import(/* webpackChunkName: "async-custom-alias" */ 'custom-alias')
 );
 
 const App = () => (

--- a/src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/index.tsx
+++ b/src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { lazy } from 'react-loosely-lazy';
 
-export const InnerLazyNested = lazy(() =>
-  import(/* webpackChunkName: "async-inner-nested-lazy" */ './main')
+export const InnerLazyNested = lazy(
+  () => import(/* webpackChunkName: "async-inner-nested-lazy" */ './main')
 );
 
 export const NestedLazy = () => (

--- a/src/webpack/__tests__/__fixtures__/app/ui/proxy/lazy.ts
+++ b/src/webpack/__tests__/__fixtures__/app/ui/proxy/lazy.ts
@@ -1,5 +1,5 @@
 import { lazyForPaint } from '../../lib/react-loosely-lazy';
 
-export const LazyProxy = lazyForPaint(() =>
-  import(/* webpackChunkName: "async-proxy" */ './index')
+export const LazyProxy = lazyForPaint(
+  () => import(/* webpackChunkName: "async-proxy" */ './index')
 );

--- a/src/webpack/index.ts
+++ b/src/webpack/index.ts
@@ -126,4 +126,4 @@ export const getAssets = (manifest: Manifest, moduleIds: string[]) =>
     []
   );
 
-export { Asset, Manifest };
+export type { Asset, Manifest };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
+    "isolatedModules": true,
     "strict": true,
     "preserveConstEnums": true,
     "jsx": "preserve",


### PR DESCRIPTION
Fix #53 . There are some cosmetic changes due to `yarn lint:fix`.