### PR TITLE
Optimise manifest and expose getAssetUrlsFromId

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -19,6 +19,7 @@
   * [`LazySuspense`](/api/lazy-suspense)
   * [`LazyWait`](/api/lazy-wait)
   * [`useLazyPhase`](/api/use-lazy-phase)
+  * [`getAssetUrlsFromId`](/api/get-asset-urls-from-id)
   
 ---
 

--- a/docs/api/get-asset-urls-from-id.md
+++ b/docs/api/get-asset-urls-from-id.md
@@ -1,0 +1,34 @@
+# `getAssetUrlsFromId(manifest, id)`
+This function retrieves the list of assets urls given a manifest and the asset identifier
+
+## Example
+```jsx
+import { getAssetUrlsFromId } from 'react-loosely-lazy';
+
+const manifest = {
+  publicPath: '/',
+  assets: {
+    './src/foo.js': ['1.js', '2.js'],
+  },
+}
+
+getAssetUrlsFromId(manifest, './src/foo.js');
+```
+
+## Arguments
+### `manifest`
+`Manifest`
+
+The manifest generated from [react-loosely-lazy/webpack plugin](tooling/webpack-plugin)
+
+---
+
+### `id`
+`string`
+
+The id of the asset, which is equivalent to [`lazy#moduleId`](api/lazy?id=moduleid) 
+
+## Return value
+`string[] | undefined`
+
+Returns the list of asset paths when the `id` is found in the manifest, otherwise it returns `undefined`

--- a/docs/guides/preloading.md
+++ b/docs/guides/preloading.md
@@ -60,7 +60,7 @@ Since the dynamic links are rendered in the React root, the performance will alw
 > The default mechanism for preloading and prefetching will render the `link` elements in the React root, which is typically in the [`Document#body`](https://developer.mozilla.org/en-US/docs/Web/API/Document/body)
 
 ### Static links
-It is possible to render the links statically in the [`Document#head`](https://developer.mozilla.org/en-US/docs/Web/API/Document/head) by retrieving the necessary assets through [`LazyComponent#getAssetUrls`](api/lazy-component?id=getasseturls)
+It is possible to render the links statically in the [`Document#head`](https://developer.mozilla.org/en-US/docs/Web/API/Document/head) by retrieving the necessary assets through [`LazyComponent#getAssetUrls`](api/lazy-component?id=getasseturls) or [`getAssetUrlsFromId`](api/get-asset-urls-from-id).
 
 To generate static links in single-page applications, a mapping between the matched route and its lazy component dependencies, needs to be available in a static context. This mapping can either be specified manually or generated via some custom automation.
 

--- a/examples/playground/manifest.json
+++ b/examples/playground/manifest.json
@@ -1,14 +1,17 @@
 {
-  "./examples/playground/components/after-paint/with-ssr.tsx": [
-    "/0.js"
-  ],
-  "./examples/playground/components/for-paint/with-ssr.tsx": [
-    "/2.js"
-  ],
-  "./examples/playground/components/custom-wait/with-ssr.tsx": [
-    "/1.js"
-  ],
-  "./examples/playground/components/lazy/without-ssr.tsx": [
-    "/3.js"
-  ]
+  "publicPath": "/",
+  "assets": {
+    "./examples/playground/components/after-paint/with-ssr.tsx": [
+      "0.js"
+    ],
+    "./examples/playground/components/for-paint/with-ssr.tsx": [
+      "2.js"
+    ],
+    "./examples/playground/components/custom-wait/with-ssr.tsx": [
+      "1.js"
+    ],
+    "./examples/playground/components/lazy/without-ssr.tsx": [
+      "3.js"
+    ]
+  }
 }

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -41,9 +41,15 @@ const createApp = ({
     moduleId: './mock',
   });
 
-  const mode = hydrate ? MODE.HYDRATE : MODE.RENDER;
-  const manifest = { './mock': [''] };
-  LooselyLazy.init({ mode, manifest });
+  LooselyLazy.init({
+    mode: hydrate ? MODE.HYDRATE : MODE.RENDER,
+    manifest: {
+      publicPath: '/',
+      assets: {
+        './mock': [''],
+      },
+    },
+  });
 
   const App = () => (
     <LazySuspense fallback={<Fallback />}>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,9 @@ export const COLLECTED = new Map();
 
 export const SETTINGS: Settings = {
   CURRENT_MODE: MODE.HYDRATE,
-  MANIFEST: {},
+  MANIFEST: {
+    publicPath: '/',
+    assets: {},
+  },
   CROSS_ORIGIN: undefined,
 };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,7 +4,12 @@ import type { ComponentType, ElementConfig, Node } from 'react';
 
 export type Asset = string;
 
-export type Manifest = { [key: string]: Asset[] };
+export type Manifest = {
+  publicPath: string,
+  assets: {
+    [id: string]: Asset[],
+  },
+};
 
 declare export var MODE: {
   RENDER: string,
@@ -90,3 +95,8 @@ declare export function useLazyPhase(): {
   startNextPhase(): void,
   resetPhase(): void,
 };
+
+declare export function getAssetUrlsFromId(
+  manifest: Manifest,
+  id: string
+): Asset[] | void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ export {
 export type { ClientLoader, Loader, ServerLoader } from './lazy';
 export type { LazyOptions, LazyComponent } from './lazy';
 
+export { getAssetUrlsFromId } from './manifest';
+export type { Asset, Manifest } from './manifest';
+
 export { LazySuspense } from './suspense';
 export type { Fallback, LazySuspenseProps } from './suspense';
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,7 +1,7 @@
 import { SETTINGS, MODE } from './constants';
 import { collect } from './collect';
+import { Manifest } from './manifest';
 import { LISTENERS, setCurrent } from './phase';
-import { Manifest } from './types';
 import { isNodeEnvironment } from './utils';
 
 type InitOptions = {

--- a/src/lazy/components/server.tsx
+++ b/src/lazy/components/server.tsx
@@ -1,7 +1,10 @@
 import React, { ComponentProps, ComponentType, useContext } from 'react';
+
 import { PHASE, SETTINGS } from '../../constants';
+import { getAssetUrlsFromId } from '../../manifest';
 import { LazySuspenseContext } from '../../suspense';
 import { getExport } from '../../utils';
+
 import { LoaderError } from '../errors/loader-error';
 import { ServerLoader } from '../loader';
 
@@ -34,7 +37,7 @@ export function createComponentServer<C extends ComponentType<any>>({
       <>
         <input type="hidden" data-lazy-begin={dataLazyId} />
         {defer !== PHASE.LAZY &&
-          SETTINGS.MANIFEST[moduleId]?.map(url => (
+          getAssetUrlsFromId(SETTINGS.MANIFEST, moduleId)?.map(url => (
             <link
               key={url}
               rel={defer === PHASE.PAINT ? 'preload' : 'prefetch'}

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -1,9 +1,9 @@
 import { ComponentProps, ComponentType, FunctionComponent } from 'react';
 
 import { PHASE, PRIORITY, SETTINGS } from '../constants';
+import { getAssetUrlsFromId } from '../manifest';
 import { PreloadPriority } from '../types';
 import { hash, displayNameFromId, isNodeEnvironment } from '../utils';
-import { Asset, Manifest } from '../webpack';
 
 import { createComponentClient } from './components/client';
 import { createComponentServer } from './components/server';
@@ -12,7 +12,6 @@ import { ClientLoader, Loader, ServerLoader } from './loader';
 import { preloadAsset } from './preload';
 import { LazyOptions, LazyComponent } from './types';
 
-export type { Asset, Manifest };
 export type { LazyOptions, LazyComponent };
 
 function lazyProxy<C extends ComponentType<any>>(
@@ -44,11 +43,7 @@ function lazyProxy<C extends ComponentType<any>>(
    * Allows getting module chunks urls
    */
   const getAssetUrls = () => {
-    if (!SETTINGS.MANIFEST[moduleId]) {
-      return;
-    }
-
-    return SETTINGS.MANIFEST[moduleId];
+    return getAssetUrlsFromId(SETTINGS.MANIFEST, moduleId);
   };
 
   /**

--- a/src/lazy/preload/__tests__/index.test.ts
+++ b/src/lazy/preload/__tests__/index.test.ts
@@ -11,12 +11,24 @@ jest.mock('../utils');
 describe('preload strategies', () => {
   describe('preloadAssetViaManifest', () => {
     afterEach(() => {
-      LooselyLazy.init({ manifest: {} });
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {},
+        },
+      });
     });
 
     it('should add link tags and return true if module found', () => {
       const loader = jest.fn();
-      LooselyLazy.init({ manifest: { '@foo/bar': ['/1.js'] } });
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {
+            '@foo/bar': ['1.js'],
+          },
+        },
+      });
 
       const result = preloadAssetViaManifest(loader, {
         moduleId: '@foo/bar',
@@ -29,8 +41,24 @@ describe('preload strategies', () => {
 
     it('should return false if module not found', () => {
       const loader = jest.fn();
-      LooselyLazy.init({ manifest: {} });
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {},
+        },
+      });
 
+      const result = preloadAssetViaManifest(loader, {
+        moduleId: '@foo/bar',
+        rel: 'preload',
+      });
+
+      expect(insertLinkTag).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the manifest is not initialised', () => {
+      const loader = jest.fn();
       const result = preloadAssetViaManifest(loader, {
         moduleId: '@foo/bar',
         rel: 'preload',
@@ -67,7 +95,12 @@ describe('preload strategies', () => {
 
     it('should return false if webpack not defined', () => {
       const loader = jest.fn();
-      LooselyLazy.init({ manifest: {} });
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {},
+        },
+      });
 
       const result = preloadAssetViaWebpack(loader, {
         moduleId: '@foo/bar',

--- a/src/lazy/preload/index.ts
+++ b/src/lazy/preload/index.ts
@@ -1,7 +1,10 @@
 import { PRIORITY, SETTINGS } from '../../constants';
+import { getAssetUrlsFromId } from '../../manifest';
 import { PreloadPriority } from '../../types';
 import { isNodeEnvironment } from '../../utils';
+
 import { Loader } from '../loader';
+
 import { insertLinkTag } from './utils';
 
 declare const __webpack_require__: any;
@@ -18,10 +21,12 @@ export function preloadAssetViaManifest(
   loader: Loader<unknown>,
   { moduleId, rel }: PreloadAssetOptions
 ) {
-  if (!SETTINGS.MANIFEST[moduleId]) {
+  const assets = getAssetUrlsFromId(SETTINGS.MANIFEST, moduleId);
+  if (!assets) {
     return false;
   }
-  SETTINGS.MANIFEST[moduleId].forEach(url => insertLinkTag(url, rel));
+
+  assets.forEach(url => insertLinkTag(url, rel));
 
   return true;
 }

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -1,0 +1,37 @@
+import { getAssetUrlsFromId } from '../index';
+
+describe('getAssetUrlsFromId', () => {
+  it('should return undefined when the id does not exist in the manifest', () => {
+    const manifest = {
+      publicPath: '/output/',
+      assets: {},
+    };
+
+    expect(getAssetUrlsFromId(manifest, 'foo')).toBeUndefined();
+  });
+
+  it('should return an empty list when there are no corresponding assets for the id', () => {
+    const manifest = {
+      publicPath: '/output/',
+      assets: {
+        foo: [],
+      },
+    };
+
+    expect(getAssetUrlsFromId(manifest, 'foo')).toEqual([]);
+  });
+
+  it('should return the corresponding list of assets for the id', () => {
+    const manifest = {
+      publicPath: '/output/',
+      assets: {
+        foo: ['async-bar.js', 'async-baz.js'],
+      },
+    };
+
+    expect(getAssetUrlsFromId(manifest, 'foo')).toEqual([
+      '/output/async-bar.js',
+      '/output/async-baz.js',
+    ]);
+  });
+});

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -1,0 +1,19 @@
+export type Asset = string;
+
+export type Manifest = {
+  publicPath: string;
+  assets: {
+    [id: string]: Asset[];
+  };
+};
+
+export const getAssetUrlsFromId = (
+  manifest: Manifest,
+  id: string
+): Asset[] | undefined => {
+  if (!manifest.assets[id]) {
+    return;
+  }
+
+  return manifest.assets[id].map(asset => `${manifest.publicPath}${asset}`);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,7 @@
 import { MODE, PRIORITY } from './constants';
+import { Manifest } from './manifest';
 
 export type PreloadPriority = typeof PRIORITY.HIGH | typeof PRIORITY.LOW;
-
-export type Asset = string;
-
-export type Manifest = { [key: string]: Asset[] };
 
 export type Settings = {
   CURRENT_MODE: typeof MODE.HYDRATE | typeof MODE.RENDER;

--- a/src/webpack/__tests__/webpack.test.ts
+++ b/src/webpack/__tests__/webpack.test.ts
@@ -1,120 +1,131 @@
+/**
+ * @jest-environment node
+ */
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import path from 'path';
-import webpack from 'webpack';
-import { ReactLooselyLazyPlugin, getAssets } from '../';
-
-const basePath = path.join(__dirname, '__fixtures__');
-const manifestFilename = 'manifest.json';
-
-const config = {
-  devtool: 'source-map' as const,
-  entry: {
-    main: path.join(basePath, 'app', 'index.tsx'),
-  },
-  mode: 'production' as const,
-  output: {
-    path: path.join(basePath, 'output'),
-    filename: '[name].js',
-    publicPath: '/output/',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            babelrc: false,
-            presets: [['@babel/preset-env', { modules: false }]],
-          },
-        },
-      },
-      {
-        test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader'],
-      },
-    ],
-  },
-  plugins: [
-    new ReactLooselyLazyPlugin({
-      filename: manifestFilename,
-    }),
-    new MiniCssExtractPlugin(),
-  ],
-  resolve: {
-    alias: {
-      'custom-alias': path.join(basePath, 'custom-alias'),
-      'react-loosely-lazy': path.join(__dirname, '../../'),
-    },
-    extensions: ['.tsx', '.ts', '.js'],
-  },
-};
-
-const expectedManifest = {
-  './src/webpack/__tests__/__fixtures__/app/ui/concatenated-module/index.tsx': [
-    '/output/async-concatenated-module.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/external-assets/index.tsx': [
-    '/output/async-external-assets.css',
-    '/output/async-external-assets.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/lazy-after-paint.tsx': [
-    '/output/async-lazy-after-paint.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/lazy-for-paint.tsx': [
-    '/output/async-lazy-for-paint.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/lazy.tsx': [
-    '/output/async-lazy.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/multiple-usages.tsx': [
-    '/output/async-multiple-usages-one.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/index.tsx': [
-    '/output/async-nested-lazy.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/main.tsx': [
-    '/output/async-inner-nested-lazy.js',
-  ],
-  './src/webpack/__tests__/__fixtures__/custom-alias/index.tsx': [
-    '/output/async-custom-alias.js',
-  ],
-};
+import webpack, { Stats } from 'webpack';
+import { Manifest, ReactLooselyLazyPlugin } from '../';
 
 describe('ReactLooselyLazyPlugin', () => {
-  it('should create the manifest', async () => {
-    const { info, manifest } = await new Promise((resolve, reject) => {
+  const testPlugin = async ({ publicPath }: { publicPath?: string } = {}) => {
+    const basePath = path.join(__dirname, '__fixtures__');
+    const manifestFilename = 'manifest.json';
+
+    const config = {
+      devtool: 'source-map' as const,
+      entry: {
+        main: path.join(basePath, 'app', 'index.tsx'),
+      },
+      mode: 'production' as const,
+      output: {
+        path: path.join(basePath, 'output'),
+        filename: '[name].js',
+        publicPath: '/output/',
+      },
+      module: {
+        rules: [
+          {
+            test: /\.tsx?$/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                babelrc: false,
+                presets: [['@babel/preset-env', { modules: false }]],
+              },
+            },
+          },
+          {
+            test: /\.css$/,
+            use: [MiniCssExtractPlugin.loader, 'css-loader'],
+          },
+        ],
+      },
+      plugins: [
+        new ReactLooselyLazyPlugin({
+          filename: manifestFilename,
+          publicPath,
+        }),
+        new MiniCssExtractPlugin(),
+      ],
+      resolve: {
+        alias: {
+          'custom-alias': path.join(basePath, 'custom-alias'),
+          'react-loosely-lazy': path.join(__dirname, '../../'),
+        },
+        extensions: ['.tsx', '.ts', '.js'],
+      },
+    };
+
+    type WebpackOutput = {
+      manifest: Manifest;
+      stats: Stats.ToJsonOutput;
+    };
+
+    const result = await new Promise<WebpackOutput>((resolve, reject) => {
       webpack(config, (err, stats) => {
         if (err) reject(err);
 
         const asset = stats.compilation.assets[manifestFilename];
         resolve({
-          info: stats.toJson(),
           manifest: JSON.parse(asset.source()),
+          stats: stats.toJson(),
         });
       });
     });
 
-    expect(info).toMatchObject({
+    const expectedManifest = {
+      publicPath: publicPath ?? '/output/',
+      assets: {
+        './src/webpack/__tests__/__fixtures__/app/ui/concatenated-module/index.tsx': [
+          'async-concatenated-module.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/external-assets/index.tsx': [
+          'async-external-assets.css',
+          'async-external-assets.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/lazy-after-paint.tsx': [
+          'async-lazy-after-paint.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/lazy-for-paint.tsx': [
+          'async-lazy-for-paint.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/lazy.tsx': [
+          'async-lazy.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/multiple-usages.tsx': [
+          'async-multiple-usages-one.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/index.tsx': [
+          'async-nested-lazy.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/app/ui/nested-lazy/main.tsx': [
+          'async-inner-nested-lazy.js',
+        ],
+        './src/webpack/__tests__/__fixtures__/custom-alias/index.tsx': [
+          'async-custom-alias.js',
+        ],
+      },
+    };
+
+    const { manifest, stats } = result;
+
+    expect(stats).toMatchObject({
       errors: [],
       warnings: [],
     });
+
     expect(manifest).toEqual(expectedManifest);
-  });
-});
+  };
 
-describe('getAssets', () => {
-  it('should return the assets based on the moduleIds provided', () => {
-    const assets = getAssets(expectedManifest, [
-      './src/webpack/__tests__/__fixtures__/app/ui/lazy-after-paint.tsx',
-      './src/webpack/__tests__/__fixtures__/app/ui/lazy-for-paint.tsx',
-      '404',
-    ]);
+  describe('should create the manifest', () => {
+    it('using the default options', async () => {
+      await testPlugin();
+    });
 
-    expect(assets).toEqual([
-      '/output/async-lazy-after-paint.js',
-      '/output/async-lazy-for-paint.js',
-      undefined,
-    ]);
+    it('with an overridden publicPath when it is provided', async () => {
+      await testPlugin({
+        publicPath: 'https://cdn.example.com/',
+      });
+    });
   });
 });


### PR DESCRIPTION
These changes update the format of the manifest, from:

```
type Manifest = { [key: string]: Asset[] };
```

to:

```
type Manifest = {
  publicPath: string;
  assets: { [key: string]: Asset[];
}
```

This helps reduce the amount of duplicate content in the file.

Additionally, a new `getAssetUrlsFromId` function is exported, replacing the unused `getAssets`.