### PR TITLE
Cleanup link tags

### DIFF
--- a/docs/api/lazy-component.md
+++ b/docs/api/lazy-component.md
@@ -26,6 +26,11 @@ If none of the above strategies are available, the [`loader`](api/lazy?id=loader
 #### Arguments
 1. `priority?: PreloadPriority` Specifies the priority that should be used to retrieve the assets. When the priority is high, the assets will be preloaded, otherwise they are prefetched.
 
+#### Return value
+`Cleanup: () => void`
+
+Returns a cleanup function that when called, will remove any inserted link tags from the document head
+
 #### Example
 
 ```jsx

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -31,9 +31,11 @@ declare export var LooselyLazy: {
 
 declare export default typeof LooselyLazy;
 
+export type Cleanup = () => void;
+
 export type LazyComponent<C> = ComponentType<ElementConfig<C>> & {
   getAssetUrls(): string[] | void,
-  preload: (priority?: typeof PRIORITY.HIGH | typeof PRIORITY.LOW) => void,
+  preload: (priority?: typeof PRIORITY.HIGH | typeof PRIORITY.LOW) => Cleanup,
 };
 
 type Options = {

--- a/src/lazy/__tests__/lazy-client.unit.test.tsx
+++ b/src/lazy/__tests__/lazy-client.unit.test.tsx
@@ -27,7 +27,7 @@ describe('lazy* on the client', () => {
 
   afterEach(() => {
     LooselyLazy.init({}); // reset settings
-    window.document.head.innerHTML = ''; // reset head
+    document.head.innerHTML = ''; // reset head
   });
 
   beforeEach(() => {
@@ -189,14 +189,7 @@ describe('lazy* on the client', () => {
     };
 
     describe('in the first phase', () => {
-      it('renders the fallback', async () => {
-        await testFallbackRender({
-          ...opts,
-          phase: PHASE.PAINT,
-        });
-      });
-
-      it('prefetches the component ahead of require', async () => {
+      beforeEach(() => {
         LooselyLazy.init({
           manifest: {
             publicPath: '/',
@@ -205,7 +198,16 @@ describe('lazy* on the client', () => {
             },
           },
         });
+      });
 
+      it('renders the fallback', async () => {
+        await testFallbackRender({
+          ...opts,
+          phase: PHASE.PAINT,
+        });
+      });
+
+      it('prefetches the component ahead of require', async () => {
         const LazyTestComponent = lazyAfterPaint(
           createClientLoader(),
           lazyOptions
@@ -217,7 +219,7 @@ describe('lazy* on the client', () => {
           </LazySuspense>
         );
 
-        expect(window.document.head).toMatchInlineSnapshot(`
+        expect(document.head).toMatchInlineSnapshot(`
           <head>
             <link
               href="/1.js"
@@ -229,6 +231,23 @@ describe('lazy* on the client', () => {
             />
           </head>
         `);
+      });
+
+      it('cleans up the inserted link tags when the component unmounts', async () => {
+        const LazyTestComponent = lazyAfterPaint(
+          createClientLoader(),
+          lazyOptions
+        );
+
+        const { unmount } = render(
+          <LazySuspense fallback="Loading...">
+            <LazyTestComponent />
+          </LazySuspense>
+        );
+
+        unmount();
+
+        expect(document.head).toMatchInlineSnapshot(`<head />`);
       });
     });
 
@@ -284,7 +303,7 @@ describe('lazy* on the client', () => {
 
     LazyTestComponent.preload();
 
-    expect(window.document.head).toMatchInlineSnapshot(`
+    expect(document.head).toMatchInlineSnapshot(`
       <head>
         <link
           href="/1.js"
@@ -308,7 +327,7 @@ describe('lazy* on the client', () => {
 
     LazyTestComponent.preload(PRIORITY.HIGH);
 
-    expect(window.document.head).toMatchInlineSnapshot(`
+    expect(document.head).toMatchInlineSnapshot(`
       <head>
         <link
           href="/1.js"

--- a/src/lazy/__tests__/utils.tsx
+++ b/src/lazy/__tests__/utils.tsx
@@ -219,10 +219,11 @@ export const testFallbackRender = async ({
     expect(queryByText('Loading...')).toBeInTheDocument();
   } else {
     expect(queryByText('Loading...')).toBeInTheDocument();
-    await waitForElementToBeRemoved(
-      () => queryByText('Loading...')
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-    ).catch(() => {});
+    await waitForElementToBeRemoved(() => queryByText('Loading...')).catch(
+      () => {
+        // We expect the loading state to remain, and this should timeout
+      }
+    );
     expect(queryByText('Default Component')).not.toBeInTheDocument();
   }
 };

--- a/src/lazy/components/client.tsx
+++ b/src/lazy/components/client.tsx
@@ -56,7 +56,8 @@ export function createComponentClient<C extends ComponentType<any>>({
         // Start preloading as will be needed soon
         useEffect(() => {
           if (!isOwnPhase) {
-            preloadAsset(deferred.preload, {
+            return preloadAsset({
+              loader: deferred.preload,
               moduleId,
               priority: PRIORITY.LOW,
             });

--- a/src/lazy/deferred.ts
+++ b/src/lazy/deferred.ts
@@ -40,8 +40,9 @@ export const createDeferred = <C extends ComponentType<any>>(
       if (deferred.result) {
         resolve(deferred.result);
 
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        return deferred.promise.then(() => {});
+        return deferred.promise.then(() => {
+          // Return void...
+        });
       } else {
         return loader().then(resolve);
       }

--- a/src/lazy/index.tsx
+++ b/src/lazy/index.tsx
@@ -55,7 +55,8 @@ function lazyProxy<C extends ComponentType<any>>(
   const preload = (priority?: PreloadPriority) => {
     const p =
       priority ?? (defer === PHASE.PAINT ? PRIORITY.HIGH : PRIORITY.LOW);
-    preloadAsset(loader, { moduleId, priority: p });
+
+    return preloadAsset({ loader, moduleId, priority: p });
   };
 
   return Object.assign(LazyInternal, {

--- a/src/lazy/preload/__tests__/index.test.ts
+++ b/src/lazy/preload/__tests__/index.test.ts
@@ -1,126 +1,395 @@
-import LooselyLazy from '../../..';
+import LooselyLazy, { PRIORITY } from '../../..';
 import {
-  preloadAssetViaLoader,
-  preloadAssetViaManifest,
-  preloadAssetViaWebpack,
+  createLoaderPreloadStrategy,
+  createManifestPreloadStrategy,
+  createWebpackPreloadStrategy,
+  preloadAsset,
+  PreloadStrategy,
 } from '..';
-import { insertLinkTag } from '../utils';
 
-jest.mock('../utils');
+let head: string;
 
-describe('preload strategies', () => {
-  describe('preloadAssetViaManifest', () => {
-    afterEach(() => {
-      LooselyLazy.init({
-        manifest: {
-          publicPath: '/',
-          assets: {},
-        },
-      });
+beforeEach(() => {
+  head = document.head.innerHTML;
+});
+
+afterEach(() => {
+  document.head.innerHTML = head;
+
+  delete (window as any).__webpack_require__;
+  delete (window as any).__webpack_get_script_filename__;
+
+  LooselyLazy.init({
+    manifest: {
+      publicPath: '/',
+      assets: {},
+    },
+  });
+});
+
+const defineWebpack = () => {
+  (window as any).__webpack_require__ = {
+    e: () => Promise.reject(),
+  };
+  (window as any).__webpack_get_script_filename__ = (id: string) => `/${id}.js`;
+};
+
+describe('createLoaderPreloadStrategy', () => {
+  it('returns the strategy', () => {
+    const loader = jest.fn();
+    const strategy = createLoaderPreloadStrategy({ loader });
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(strategy).toEqual(expect.any(Function));
+  });
+
+  describe('strategy', () => {
+    it('calls the loader', () => {
+      const loader = jest.fn();
+      const strategy = createLoaderPreloadStrategy({ loader });
+
+      strategy();
+
+      expect(loader).toHaveBeenCalled();
     });
 
-    it('should add link tags and return true if module found', () => {
-      const loader = jest.fn();
+    it('returns a cleanup function that does nothing', () => {
+      const strategy = createLoaderPreloadStrategy({ loader: jest.fn() });
+      const cleanup = strategy();
+
+      expect(cleanup).not.toThrow();
+    });
+  });
+});
+
+describe('createManifestPreloadStrategy', () => {
+  it('throws an unsupported error when the manifest is not initialised', () => {
+    expect(() =>
+      createManifestPreloadStrategy({
+        moduleId: '@foo/bar',
+        rel: 'preload',
+      })
+    ).toThrow('Unsupported preload strategy');
+  });
+
+  it('throws an unsupported error when the module does not exist in the manifest', () => {
+    LooselyLazy.init({
+      manifest: {
+        publicPath: '/',
+        assets: {},
+      },
+    });
+
+    expect(() =>
+      createManifestPreloadStrategy({
+        moduleId: '@foo/bar',
+        rel: 'preload',
+      })
+    ).toThrow('Unsupported preload strategy');
+  });
+
+  it('returns the strategy when the module is in the manifest', () => {
+    LooselyLazy.init({
+      manifest: {
+        publicPath: '/',
+        assets: {
+          '@foo/bar': ['1.js'],
+        },
+      },
+    });
+
+    const strategy = createManifestPreloadStrategy({
+      moduleId: '@foo/bar',
+      rel: 'preload',
+    });
+
+    expect(document.head).toMatchInlineSnapshot(`<head />`);
+    expect(strategy).toEqual(expect.any(Function));
+  });
+
+  describe('strategy', () => {
+    let strategy: PreloadStrategy;
+
+    beforeEach(() => {
       LooselyLazy.init({
         manifest: {
           publicPath: '/',
           assets: {
-            '@foo/bar': ['1.js'],
+            '@foo/bar': [
+              'async-manifest-strategy-1.js',
+              'async-manifest-strategy-2.js',
+            ],
           },
         },
       });
 
-      const result = preloadAssetViaManifest(loader, {
+      strategy = createManifestPreloadStrategy({
         moduleId: '@foo/bar',
         rel: 'preload',
       });
-
-      expect(insertLinkTag).toHaveBeenCalledWith('/1.js', 'preload');
-      expect(result).toBe(true);
     });
 
-    it('should return false if module not found', () => {
-      const loader = jest.fn();
-      LooselyLazy.init({
-        manifest: {
-          publicPath: '/',
-          assets: {},
-        },
-      });
+    it('inserts the manifest module assets as link tags', () => {
+      strategy();
 
-      const result = preloadAssetViaManifest(loader, {
-        moduleId: '@foo/bar',
-        rel: 'preload',
-      });
-
-      expect(insertLinkTag).not.toHaveBeenCalled();
-      expect(result).toBe(false);
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <link
+            href="/async-manifest-strategy-1.js"
+            rel="preload"
+          />
+          <link
+            href="/async-manifest-strategy-2.js"
+            rel="preload"
+          />
+        </head>
+      `);
     });
 
-    it('should return false when the manifest is not initialised', () => {
-      const loader = jest.fn();
-      const result = preloadAssetViaManifest(loader, {
-        moduleId: '@foo/bar',
-        rel: 'preload',
-      });
+    it('returns a function that cleans up inserted link tags', () => {
+      const cleanup = strategy();
 
-      expect(insertLinkTag).not.toHaveBeenCalled();
-      expect(result).toBe(false);
+      cleanup();
+
+      expect(document.head).toMatchInlineSnapshot(`<head />`);
     });
   });
+});
 
-  describe('preloadAssetViaWebpack', () => {
-    afterEach(() => {
-      delete (window as any).__webpack_require__;
-      delete (window as any).__webpack_get_script_filename__;
-    });
-
-    it('should add link tags and return true if webpack env', () => {
-      (window as any).__webpack_require__ = {
-        e: () => Promise.reject(),
-      };
-      (window as any).__webpack_get_script_filename__ = (id: string) =>
-        `/${id}.js`;
-
-      const chunkId = 1;
-      const loader = () => (window as any).__webpack_require__.e(chunkId);
-      const result = preloadAssetViaWebpack(loader, {
-        moduleId: '@foo/bar',
+describe('createWebpackPreloadStrategy', () => {
+  it('throws an unsupported error when webpack is not defined', () => {
+    expect(() =>
+      createWebpackPreloadStrategy({
+        loader: jest.fn(),
         rel: 'prefetch',
-      });
-
-      expect(insertLinkTag).toHaveBeenCalledWith('/1.js', 'prefetch');
-      expect(result).toBe(true);
-    });
-
-    it('should return false if webpack not defined', () => {
-      const loader = jest.fn();
-      LooselyLazy.init({
-        manifest: {
-          publicPath: '/',
-          assets: {},
-        },
-      });
-
-      const result = preloadAssetViaWebpack(loader, {
-        moduleId: '@foo/bar',
-        rel: 'prefetch',
-      });
-
-      expect(insertLinkTag).not.toHaveBeenCalled();
-      expect(result).toBe(false);
-    });
+      })
+    ).toThrow('Unsupported preload strategy');
   });
 
-  describe('preloadAssetViaLoader', () => {
-    it('should call the loader and return true', () => {
-      const loader = jest.fn();
+  it('returns the strategy when webpack is defined', () => {
+    defineWebpack();
 
-      const result = preloadAssetViaLoader(loader);
+    const loader = jest.fn();
+    const strategy = createWebpackPreloadStrategy({
+      loader,
+      rel: 'preload',
+    });
 
-      expect(insertLinkTag).not.toHaveBeenCalled();
+    expect(loader).not.toHaveBeenCalled();
+    expect(strategy).toEqual(expect.any(Function));
+  });
+
+  describe('strategy', () => {
+    let loader: jest.Mock;
+    let strategy: PreloadStrategy;
+
+    beforeEach(() => {
+      defineWebpack();
+
+      loader = jest.fn(() =>
+        Promise.all([
+          (window as any).__webpack_require__.e('async-webpack-strategy-1'),
+          (window as any).__webpack_require__.e('async-webpack-strategy-2'),
+        ])
+      );
+
+      strategy = createWebpackPreloadStrategy({
+        loader,
+        rel: 'preload',
+      });
+    });
+
+    it('inserts the link tags for the asset', () => {
+      strategy();
+
       expect(loader).toHaveBeenCalled();
-      expect(result).toBe(true);
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <link
+            href="/async-webpack-strategy-1.js"
+            rel="preload"
+          />
+          <link
+            href="/async-webpack-strategy-2.js"
+            rel="preload"
+          />
+        </head>
+      `);
+    });
+
+    it('returns a function that cleans up inserted link tags', () => {
+      const cleanup = strategy();
+
+      cleanup();
+
+      expect(document.head).toMatchInlineSnapshot(`<head />`);
+    });
+  });
+});
+
+describe('preloadAsset', () => {
+  const webpackLoader = () =>
+    Promise.all([
+      (window as any).__webpack_require__.e('async-webpack-strategy-1'),
+      (window as any).__webpack_require__.e('async-webpack-strategy-2'),
+    ]);
+
+  const moduleId = '@foo/bar';
+
+  describe('when all strategies are available', () => {
+    beforeEach(() => {
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {
+            [moduleId]: [
+              'async-manifest-strategy-1.js',
+              'async-manifest-strategy-2.js',
+            ],
+          },
+        },
+      });
+
+      defineWebpack();
+    });
+
+    it('preloads the assets through the manifest strategy', () => {
+      preloadAsset({
+        loader: webpackLoader,
+        moduleId,
+        priority: PRIORITY.HIGH,
+      });
+
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <link
+            href="/async-manifest-strategy-1.js"
+            rel="preload"
+          />
+          <link
+            href="/async-manifest-strategy-2.js"
+            rel="preload"
+          />
+        </head>
+      `);
+    });
+
+    it('returns a function that cleans up inserted link tags', () => {
+      preloadAsset({
+        loader: webpackLoader,
+        moduleId,
+        priority: PRIORITY.HIGH,
+      })();
+
+      expect(document.head).toMatchInlineSnapshot(`<head />`);
+    });
+  });
+
+  describe('when the manifest strategy is not available', () => {
+    beforeEach(() => {
+      defineWebpack();
+    });
+
+    it('preloads the assets through the webpack strategy', () => {
+      preloadAsset({
+        loader: webpackLoader,
+        moduleId,
+        priority: PRIORITY.HIGH,
+      });
+
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <link
+            href="/async-webpack-strategy-1.js"
+            rel="preload"
+          />
+          <link
+            href="/async-webpack-strategy-2.js"
+            rel="preload"
+          />
+        </head>
+      `);
+    });
+
+    it('returns a function that cleans up inserted link tags', () => {
+      preloadAsset({
+        loader: webpackLoader,
+        moduleId,
+        priority: PRIORITY.HIGH,
+      })();
+
+      expect(document.head).toMatchInlineSnapshot(`<head />`);
+    });
+  });
+
+  describe('when the webpack strategy is not available', () => {
+    beforeEach(() => {
+      LooselyLazy.init({
+        manifest: {
+          publicPath: '/',
+          assets: {
+            [moduleId]: [
+              'async-manifest-strategy-1.js',
+              'async-manifest-strategy-2.js',
+            ],
+          },
+        },
+      });
+    });
+
+    it('preloads the assets through the manifest strategy', () => {
+      preloadAsset({
+        loader: jest.fn(),
+        moduleId,
+        priority: PRIORITY.HIGH,
+      });
+
+      expect(document.head).toMatchInlineSnapshot(`
+        <head>
+          <link
+            href="/async-manifest-strategy-1.js"
+            rel="preload"
+          />
+          <link
+            href="/async-manifest-strategy-2.js"
+            rel="preload"
+          />
+        </head>
+      `);
+    });
+
+    it('returns a function that cleans up inserted link tags', () => {
+      preloadAsset({
+        loader: jest.fn(),
+        moduleId,
+        priority: PRIORITY.HIGH,
+      })();
+
+      expect(document.head).toMatchInlineSnapshot(`<head />`);
+    });
+  });
+
+  describe('when the manifest and webpack strategy are not available', () => {
+    it('preloads the assets through the loader strategy', () => {
+      const loader = jest.fn();
+
+      preloadAsset({
+        loader,
+        moduleId,
+        priority: PRIORITY.HIGH,
+      });
+
+      expect(loader).toHaveBeenCalled();
+    });
+
+    it('returns a cleanup function that does nothing', () => {
+      const cleanup = preloadAsset({
+        loader: jest.fn(),
+        moduleId,
+        priority: PRIORITY.HIGH,
+      });
+
+      expect(cleanup).not.toThrow();
     });
   });
 });

--- a/src/lazy/preload/utils.ts
+++ b/src/lazy/preload/utils.ts
@@ -1,14 +1,16 @@
 import { getConfig } from '../../config';
 
+export const noopCleanup = () => {
+  // Nothing to cleanup...
+};
+
 export function insertLinkTag(href: string, rel: string) {
   // Skip if already preloaded, prefetched, or loaded
   if (
     document.querySelector(`link[href="${href}"]`) ||
     document.querySelector(`script[src="${href}"]`)
   )
-    return () => {
-      // Nothing to cleanup...
-    };
+    return noopCleanup;
 
   const { crossOrigin } = getConfig();
   const link = document.createElement('link');
@@ -21,8 +23,8 @@ export function insertLinkTag(href: string, rel: string) {
   document.head?.appendChild(link);
 
   return () => {
-    // Remove the child if it is still in the document head
-    if (document.head?.contains(link)) {
+    // Remove the link if it is still in the document head
+    if (link.parentNode === document.head) {
       document.head?.removeChild(link);
     }
   };

--- a/src/lazy/preload/utils.ts
+++ b/src/lazy/preload/utils.ts
@@ -1,12 +1,14 @@
 import { getConfig } from '../../config';
 
 export function insertLinkTag(href: string, rel: string) {
-  // if already preloaded/prefetched/loaded, skip
+  // Skip if already preloaded, prefetched, or loaded
   if (
     document.querySelector(`link[href="${href}"]`) ||
     document.querySelector(`script[src="${href}"]`)
   )
-    return;
+    return () => {
+      // Nothing to cleanup...
+    };
 
   const { crossOrigin } = getConfig();
   const link = document.createElement('link');
@@ -17,4 +19,11 @@ export function insertLinkTag(href: string, rel: string) {
   link.href = href;
 
   document.head?.appendChild(link);
+
+  return () => {
+    // Remove the child if it is still in the document head
+    if (document.head?.contains(link)) {
+      document.head?.removeChild(link);
+    }
+  };
 }

--- a/src/lazy/types.ts
+++ b/src/lazy/types.ts
@@ -1,5 +1,6 @@
 import { ComponentProps, ComponentType, FunctionComponent } from 'react';
 import { PreloadPriority } from '../types';
+import { Cleanup } from './preload';
 
 export type LazyOptions = {
   /**
@@ -21,6 +22,6 @@ export type LazyOptions = {
 export type LazyComponent<C extends ComponentType<any>> = FunctionComponent<
   ComponentProps<C>
 > & {
-  preload: (priority?: PreloadPriority) => void;
+  preload: (priority?: PreloadPriority) => Cleanup;
   getAssetUrls: () => string[] | undefined;
 };


### PR DESCRIPTION
These changes will resolve https://github.com/atlassian-labs/react-loosely-lazy/issues/59 by:

1. Returning a cleanup function in `LazyComponent#preload`
2. Cleaning up the `preloadAsset` for after paint components in the `useEffect`

## Changes
* Update documentation and types
* Refactor preload strategy handling to throw an error when it is invalid, instead of returning a boolean. The `preloadAsset` will then always picks the first valid strategy.
* Add a test that verifies unmounting behaviour of a `lazyAfterPaint` component
* Add more thorough tests in the `preload` directory, which covers each individual strategy and the expected behaviour of `preloadAsset`
* Remove any existing `@typescript-eslint/no-empty-function` violations by adding in comments into the function body, which is the recommended practice