### PR TITLE
Use Infinity over undefined for retry

### DIFF
--- a/docs/api/init.md
+++ b/docs/api/init.md
@@ -58,7 +58,7 @@ Specifies whether the library should run in render or hydrate mode, and should b
 </div>
 
 ### `retry?`
-`number | undefined = 2`
+`number = 2`
 
 Configures the amount of times to retry the [`loader`](api/lazy?id=loader), when it returns a rejected promise.
 
@@ -66,6 +66,6 @@ Configures the amount of times to retry the [`loader`](api/lazy?id=loader), when
 
 | Value     | Behaviour               |
 | --------- | ----------------------- |
-| undefined | Retry indefinitely      |
 | 0         | Do not retry on failure |
 | 1...n     | Retry n times           |
+| Infinity  | Retry indefinitely      |

--- a/src/lazy/retry/index.tsx
+++ b/src/lazy/retry/index.tsx
@@ -4,13 +4,7 @@ export type RetryPolicy = {
   maxAttempts: number;
 };
 
-export type RetryPolicyConfiguration = Omit<
-  Partial<RetryPolicy>,
-  'maxAttempts'
-> &
-  Partial<{
-    maxAttempts: number | undefined;
-  }>;
+export type RetryPolicyConfiguration = Partial<RetryPolicy>;
 
 type AttemptContext = {
   attempt: number;
@@ -41,15 +35,12 @@ const sleep = (delay: number) =>
 const getPolicy = (configuration: Partial<RetryPolicy>): RetryPolicy => ({
   delay: Math.max(0, configuration.delay ?? 0),
   factor: Math.max(0, configuration.factor ?? 0),
-  maxAttempts:
-    typeof configuration.maxAttempts === 'number'
-      ? Math.max(0, configuration.maxAttempts)
-      : Infinity,
+  maxAttempts: Math.max(0, configuration.maxAttempts ?? 0),
 });
 
 export function retry<T>(
   retryable: Retryable<T>,
-  policyConfiguration: RetryPolicyConfiguration = { maxAttempts: 0 }
+  policyConfiguration: RetryPolicyConfiguration = {}
 ) {
   const policy = getPolicy(policyConfiguration);
 


### PR DESCRIPTION
These changes remove `undefined` as an option to `retry`, allowing the global configuration to only accept a number type. This change should make the API more straightforward to understand.