### PR TITLE
JSDom no longer sets `window.name`

### DIFF
--- a/packages/core/react-loosely-lazy/src/utils/index.ts
+++ b/packages/core/react-loosely-lazy/src/utils/index.ts
@@ -15,15 +15,7 @@ export const displayNameFromId = (id: string) => {
  * @see https://github.com/jsdom/jsdom/issues/1537
  */
 export const isNodeEnvironment = () => {
-  if (typeof window === 'undefined') {
-    return true;
-  }
-
-  if (window.name === 'nodejs') {
-    return true;
-  }
-
-  return false;
+  return globalThis !== globalThis.window;
 };
 
 export function attrToProp(props: { [k: string]: string }, attr: Attr) {


### PR DESCRIPTION
Fixes #96