### PR TITLE
Add children to LazySuspenseProps

### DIFF
--- a/packages/core/react-loosely-lazy/src/suspense/types.ts
+++ b/packages/core/react-loosely-lazy/src/suspense/types.ts
@@ -1,4 +1,4 @@
-import { SuspenseProps } from 'react';
+import type { SuspenseProps } from 'react';
 
 export type Fallback = SuspenseProps['fallback'];
 
@@ -8,5 +8,6 @@ export type LazySuspenseContextType = {
 };
 
 export type LazySuspenseProps = {
+  children?: SuspenseProps['children'];
   fallback: Fallback;
 };


### PR DESCRIPTION
Add `children` to `SuspenseProps` to support newer React type versions

## Types

`@types/react` contains the following definition for `Component` in React versions 17 and below:

```
class Component<P, S> {
  // ...
  readonly props: Readonly<P> & Readonly<{ children?: ReactNode | undefined }>;
}
```

React 18+ uses:

```
class Component<P, S> {
  // ...
  readonly props: Readonly<P>;
}
```