### PR TITLE
Added a simple profiler for capturing load times

### DIFF
--- a/packages/core/react-loosely-lazy/src/index.ts
+++ b/packages/core/react-loosely-lazy/src/index.ts
@@ -26,3 +26,5 @@ export { LazySuspense } from './suspense';
 export type { Fallback, LazySuspenseProps } from './suspense';
 
 export { useLazyPhase } from './phase';
+
+export { GlobalReactLooselyLazyProfiler, ProfilerContext } from './profiler';

--- a/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
@@ -45,7 +45,7 @@ export function createComponentClient<C extends ComponentType<any>>({
       started: false,
     }));
 
-    const profiler = useContext(ProfilerContext);
+    const profiler = useContext(ProfilerContext).current;
 
     const load = () => {
       if (status.started || !status.phase || !status.noWait) {
@@ -57,9 +57,9 @@ export function createComponentClient<C extends ComponentType<any>>({
       if (profiler) {
         const eventInfo = { identifier: moduleId };
         onResolve = () => {
-          profiler?.onLoadComplete?.(eventInfo);
+          profiler.onLoadComplete(eventInfo);
         };
-        profiler?.onLoadStart?.(eventInfo);
+        profiler.onLoadStart(eventInfo);
       }
 
       const result = deferred.start().catch((err: Error) => {

--- a/packages/core/react-loosely-lazy/src/lazy/preload/index.ts
+++ b/packages/core/react-loosely-lazy/src/lazy/preload/index.ts
@@ -10,6 +10,7 @@ import { Loader } from '../loader';
 import { PreloadPriority } from '../types';
 
 import { insertLinkTag } from './utils';
+import { GlobalReactLooselyLazyProfiler } from '../../profiler';
 
 declare const __webpack_require__: any;
 declare function __webpack_get_script_filename__(chunkId: string): string;
@@ -103,6 +104,8 @@ export function preloadAsset({
   priority,
 }: PreloadAssetOptions): Cleanup {
   if (isNodeEnvironment()) return noopCleanup;
+
+  GlobalReactLooselyLazyProfiler.current?.onPreload(moduleId, priority);
 
   const rel = priority === PRIORITY.HIGH ? 'preload' : 'prefetch';
   const preloadStrategies = [

--- a/packages/core/react-loosely-lazy/src/lazy/preload/utils.ts
+++ b/packages/core/react-loosely-lazy/src/lazy/preload/utils.ts
@@ -18,18 +18,18 @@ export function insertLinkTag(href: string, rel: string) {
   if (crossOrigin) link.crossOrigin = crossOrigin;
   link.href = href;
 
-  const profiler = GlobalReactLooselyLazyProfiler;
+  const profiler = GlobalReactLooselyLazyProfiler.current;
   let removableListener: (() => void) | null = null;
-  if (profiler && profiler.onLoadStart && profiler.onLoadComplete) {
+  if (profiler) {
     const eventInfo = { identifier: href };
     const listener = () => {
       link.removeEventListener('onload', listener);
       removableListener = null;
-      profiler?.onLoadComplete?.(eventInfo);
+      profiler.onLoadComplete(eventInfo);
     };
     link.addEventListener('onload', listener);
     removableListener = listener;
-    profiler.onLoadStart?.(eventInfo);
+    profiler.onLoadStart(eventInfo);
   }
 
   document.head?.appendChild(link);

--- a/packages/core/react-loosely-lazy/src/profiler/__tests__/profiler.integration.test.tsx
+++ b/packages/core/react-loosely-lazy/src/profiler/__tests__/profiler.integration.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { insertLinkTag } from '../../lazy/preload/utils';
 import { LazySuspense } from '../../suspense';
-import * as profiler from '../index';
+import { GlobalReactLooselyLazyProfiler, ProfilerContext } from '../index';
 import { render } from '@testing-library/react';
 import { LooselyLazy } from '../../init';
 import { lazyForPaint } from '../../lazy';
@@ -13,10 +13,10 @@ describe('profiler', () => {
   const globalOnLoadComplete = jest.fn();
 
   beforeEach(() => {
-    profiler.setGlobalReactLooselyLazyProfilerInstance({
+    GlobalReactLooselyLazyProfiler.current = {
       onLoadStart: globalOnLoadStart,
       onLoadComplete: globalOnLoadComplete,
-    });
+    };
   });
 
   afterEach(() => {
@@ -68,8 +68,10 @@ describe('profiler', () => {
 
     it('should collect start and end times from client component', async () => {
       const context = {
-        onLoadStart: contextOnLoadStart,
-        onLoadComplete: contextOnLoadComplete,
+        current: {
+          onLoadStart: contextOnLoadStart,
+          onLoadComplete: contextOnLoadComplete,
+        },
       };
 
       const TestComponent = () => <div>A component</div>;
@@ -81,11 +83,11 @@ describe('profiler', () => {
       );
 
       render(
-        <profiler.ProfilerContext.Provider value={context}>
+        <ProfilerContext.Provider value={context}>
           <LazySuspense fallback={null}>
             <LazyTestComponent />
           </LazySuspense>
-        </profiler.ProfilerContext.Provider>
+        </ProfilerContext.Provider>
       );
 
       expect(contextOnLoadStart).toHaveBeenCalledWith({
@@ -102,8 +104,10 @@ describe('profiler', () => {
 
     it('should not collect end time when component fails to load', async () => {
       const context = {
-        onLoadStart: contextOnLoadStart,
-        onLoadComplete: contextOnLoadComplete,
+        current: {
+          onLoadStart: contextOnLoadStart,
+          onLoadComplete: contextOnLoadComplete,
+        },
       };
 
       const LazyFailComponent = lazyForPaint(
@@ -114,11 +118,11 @@ describe('profiler', () => {
       );
 
       render(
-        <profiler.ProfilerContext.Provider value={context}>
+        <ProfilerContext.Provider value={context}>
           <LazySuspense fallback={null}>
             <LazyFailComponent />
           </LazySuspense>
-        </profiler.ProfilerContext.Provider>
+        </ProfilerContext.Provider>
       );
 
       expect(contextOnLoadStart).toHaveBeenCalledWith({

--- a/packages/core/react-loosely-lazy/src/profiler/__tests__/profiler.integration.test.tsx
+++ b/packages/core/react-loosely-lazy/src/profiler/__tests__/profiler.integration.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { insertLinkTag } from '../../lazy/preload/utils';
+import { LazySuspense } from '../../suspense';
+import * as profiler from '../index';
+import { render } from '@testing-library/react';
+import { LooselyLazy } from '../../init';
+import { lazyForPaint } from '../../lazy';
+
+const nextTick = async () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('profiler', () => {
+  const globalOnLoadStart = jest.fn();
+  const globalOnLoadComplete = jest.fn();
+
+  beforeEach(() => {
+    profiler.setGlobalReactLooselyLazyProfilerInstance({
+      onLoadStart: globalOnLoadStart,
+      onLoadComplete: globalOnLoadComplete,
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('global profiler', () => {
+    it('should collect start and end times from insertLinkTag', () => {
+      const dispose = insertLinkTag('/example', 'preload');
+
+      const tag = document.querySelector('link[href="/example"]');
+
+      expect(globalOnLoadStart).toHaveBeenCalledTimes(1);
+      expect(globalOnLoadStart).toHaveBeenCalledWith({
+        identifier: '/example',
+      });
+      expect(globalOnLoadComplete).not.toHaveBeenCalled();
+
+      expect(tag).not.toBeNull();
+      tag?.dispatchEvent(new Event('onload'));
+      dispose();
+
+      expect(globalOnLoadStart).toHaveBeenCalledTimes(1);
+      expect(globalOnLoadComplete).toHaveBeenCalledTimes(1);
+      expect(globalOnLoadComplete).toHaveBeenCalledWith({
+        identifier: '/example',
+      });
+    });
+
+    it('should not collect end time when link has been disposed of before load completes', () => {
+      const dispose = insertLinkTag('/example', 'preload');
+
+      document.querySelector('link[href="/example"]');
+
+      dispose();
+
+      expect(globalOnLoadStart).toHaveBeenCalledTimes(1);
+      expect(globalOnLoadComplete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('context profiler', () => {
+    const contextOnLoadStart = jest.fn();
+    const contextOnLoadComplete = jest.fn();
+
+    beforeEach(() => {
+      LooselyLazy.init({});
+    });
+
+    it('should collect start and end times from client component', async () => {
+      const context = {
+        onLoadStart: contextOnLoadStart,
+        onLoadComplete: contextOnLoadComplete,
+      };
+
+      const TestComponent = () => <div>A component</div>;
+      const LazyTestComponent = lazyForPaint(
+        () => Promise.resolve({ default: TestComponent }),
+        {
+          moduleId: 'success module',
+        }
+      );
+
+      render(
+        <profiler.ProfilerContext.Provider value={context}>
+          <LazySuspense fallback={null}>
+            <LazyTestComponent />
+          </LazySuspense>
+        </profiler.ProfilerContext.Provider>
+      );
+
+      expect(contextOnLoadStart).toHaveBeenCalledWith({
+        identifier: 'success module',
+      });
+      expect(contextOnLoadComplete).not.toHaveBeenCalled();
+
+      await nextTick();
+
+      expect(contextOnLoadComplete).toHaveBeenCalledWith({
+        identifier: 'success module',
+      });
+    });
+
+    it('should not collect end time when component fails to load', async () => {
+      const context = {
+        onLoadStart: contextOnLoadStart,
+        onLoadComplete: contextOnLoadComplete,
+      };
+
+      const LazyFailComponent = lazyForPaint(
+        () => Promise.reject('Module failed to load'),
+        {
+          moduleId: 'fail module',
+        }
+      );
+
+      render(
+        <profiler.ProfilerContext.Provider value={context}>
+          <LazySuspense fallback={null}>
+            <LazyFailComponent />
+          </LazySuspense>
+        </profiler.ProfilerContext.Provider>
+      );
+
+      expect(contextOnLoadStart).toHaveBeenCalledWith({
+        identifier: 'fail module',
+      });
+      expect(contextOnLoadComplete).not.toHaveBeenCalled();
+
+      await nextTick();
+
+      expect(contextOnLoadComplete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/react-loosely-lazy/src/profiler/index.ts
+++ b/packages/core/react-loosely-lazy/src/profiler/index.ts
@@ -1,0 +1,25 @@
+import { createContext } from 'react';
+
+export type EventInfo = {
+  identifier: string;
+};
+
+export type Profiler = {
+  onLoadStart?(info: EventInfo): void;
+  onLoadComplete?(info: EventInfo): void;
+};
+
+let globalInstance: Profiler | undefined;
+export function setGlobalReactLooselyLazyProfilerInstance(instance: Profiler) {
+  globalInstance = instance;
+}
+
+const globalInstanceProxy = {
+  onLoadStart: (info: EventInfo) => globalInstance?.onLoadStart?.(info),
+  onLoadComplete: (info: EventInfo) => globalInstance?.onLoadComplete?.(info),
+};
+
+export const GlobalReactLooselyLazyProfiler: Readonly<Profiler> =
+  globalInstanceProxy;
+
+export const ProfilerContext = createContext<Profiler>(globalInstanceProxy);

--- a/packages/core/react-loosely-lazy/src/profiler/index.ts
+++ b/packages/core/react-loosely-lazy/src/profiler/index.ts
@@ -1,10 +1,12 @@
 import { createContext } from 'react';
+import { PreloadPriority } from '../lazy/types';
 
 export type EventInfo = {
   identifier: string;
 };
 
 type Profiler = {
+  onPreload(moduleId: string, priority?: PreloadPriority): void;
   onLoadStart(info: EventInfo): void;
   onLoadComplete(info: EventInfo): void;
 };

--- a/packages/core/react-loosely-lazy/src/profiler/index.ts
+++ b/packages/core/react-loosely-lazy/src/profiler/index.ts
@@ -4,22 +4,19 @@ export type EventInfo = {
   identifier: string;
 };
 
-export type Profiler = {
-  onLoadStart?(info: EventInfo): void;
-  onLoadComplete?(info: EventInfo): void;
+type Profiler = {
+  onLoadStart(info: EventInfo): void;
+  onLoadComplete(info: EventInfo): void;
 };
 
-let globalInstance: Profiler | undefined;
-export function setGlobalReactLooselyLazyProfilerInstance(instance: Profiler) {
-  globalInstance = instance;
-}
-
-const globalInstanceProxy = {
-  onLoadStart: (info: EventInfo) => globalInstance?.onLoadStart?.(info),
-  onLoadComplete: (info: EventInfo) => globalInstance?.onLoadComplete?.(info),
+export type ProfilerContextType = {
+  current: Profiler | null;
 };
 
-export const GlobalReactLooselyLazyProfiler: Readonly<Profiler> =
-  globalInstanceProxy;
+export const GlobalReactLooselyLazyProfiler: ProfilerContextType = {
+  current: null,
+};
 
-export const ProfilerContext = createContext<Profiler>(globalInstanceProxy);
+export const ProfilerContext = createContext<ProfilerContextType>(
+  GlobalReactLooselyLazyProfiler
+);


### PR DESCRIPTION
We'd like to be able to record the start and end times for each loading module.

This change provides two levels of profiling: a global profiler and a context level profiler. Some notes about these:
* By default they are no-op
* To set the instance used by `GlobalReactLooselyLazyProfiler`, call `setGlobalReactLooselyLazyProfilerInstance` from this package.
* To set the instance used by `ProfilerContext` use the regular React context pattern
  ```
  // We can use more contextual data from this provider component in our profiling records.
  const instance = {
    onLoadStart: ...
    onLoadComplete: ...
  };
  
  return (
    <ProfilerContext.Provider value={instance}>
      <MyLazyComponent />
    </ProfilerContext>
  );
  ```
* Lazy modules preloaded will use the global instance while instances loaded by `<LazySuspense>` will use the contextual profiler.
* By default if you don't set a profiler context it will push through to the `GlobalReactLooselyLazyProfiler` instance.

NOTE: The two profilers receive different identifying data at the moment (href vs. moduleId). At present we're hoping to resolve this at processing time which avoids having to pass `moduleId` into `insertLinkTag`.