### PR TITLE
Non browser environments fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19409,11 +19409,11 @@
     },
     "packages/core/manifest": {
       "name": "@react-loosely-lazy/manifest",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0"
     },
     "packages/core/react-loosely-lazy": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@testing-library/react": "^11.2.7",
@@ -19422,13 +19422,13 @@
         "react-dom": "^16.14.0"
       },
       "peerDependencies": {
-        "@react-loosely-lazy/manifest": "1.0.0",
+        "@react-loosely-lazy/manifest": "1.1.0",
         "react": "^16.9.0 || ^17.0.0-0"
       }
     },
     "packages/plugins/babel": {
       "name": "@react-loosely-lazy/babel-plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "enhanced-resolve": "^5.8.2"
@@ -19443,7 +19443,7 @@
     },
     "packages/plugins/parcel-reporter-manifest": {
       "name": "@react-loosely-lazy/parcel-reporter-manifest",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@parcel/plugin": "2.0.0-rc.0"
@@ -19453,19 +19453,19 @@
         "@parcel/core": "2.0.0-rc.0",
         "@parcel/fs": "2.0.0-rc.0",
         "@parcel/types": "2.0.0-rc.0",
-        "@react-loosely-lazy/integration-app": "^1.0.0",
-        "@react-loosely-lazy/manifest": "^1.0.0"
+        "@react-loosely-lazy/integration-app": "^1.1.0",
+        "@react-loosely-lazy/manifest": "^1.1.0"
       },
       "engines": {
         "parcel": "^2.0.0-rc.0"
       },
       "peerDependencies": {
-        "@react-loosely-lazy/manifest": "1.0.0"
+        "@react-loosely-lazy/manifest": "1.1.0"
       }
     },
     "packages/plugins/parcel-transformer": {
       "name": "@react-loosely-lazy/parcel-transformer",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@parcel/plugin": "^2.0.0-rc.0"
@@ -19473,7 +19473,7 @@
       "devDependencies": {
         "@parcel/config-default": "2.0.0-rc.0",
         "@parcel/core": "2.0.0-rc.0",
-        "@react-loosely-lazy/integration-app": "^1.0.0"
+        "@react-loosely-lazy/integration-app": "^1.1.0"
       },
       "engines": {
         "parcel": "^2.0.0-rc.0"
@@ -19481,11 +19481,11 @@
     },
     "packages/plugins/webpack": {
       "name": "@react-loosely-lazy/webpack-plugin",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@react-loosely-lazy/integration-app": "^1.0.0",
-        "@react-loosely-lazy/manifest": "^1.0.0",
+        "@react-loosely-lazy/integration-app": "^1.1.0",
+        "@react-loosely-lazy/manifest": "^1.1.0",
         "@types/mini-css-extract-plugin": "^1.4.3",
         "@types/react": "^16.14.8",
         "@types/react-dom": "^16.9.13",
@@ -19494,22 +19494,22 @@
         "mini-css-extract-plugin": "^1.6.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-loosely-lazy": "1.0.0",
+        "react-loosely-lazy": "1.1.0",
         "tsconfig-paths-webpack-plugin": "^3.5.1",
         "webpack": "^4.46.0"
       },
       "peerDependencies": {
-        "@react-loosely-lazy/manifest": "1.0.0",
+        "@react-loosely-lazy/manifest": "1.1.0",
         "webpack": "^4.x"
       }
     },
     "packages/testing/integration-app": {
       "name": "@react-loosely-lazy/integration-app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "react": "^16.14.0",
-        "react-loosely-lazy": "^1.0.0"
+        "react-loosely-lazy": "^1.1.0"
       },
       "devDependencies": {
         "@types/react": "^16.14.8"
@@ -22054,7 +22054,7 @@
       "requires": {
         "@types/react": "^16.14.8",
         "react": "^16.14.0",
-        "react-loosely-lazy": "^1.0.0"
+        "react-loosely-lazy": "^1.1.0"
       }
     },
     "@react-loosely-lazy/manifest": {
@@ -22068,8 +22068,8 @@
         "@parcel/fs": "2.0.0-rc.0",
         "@parcel/plugin": "2.0.0-rc.0",
         "@parcel/types": "2.0.0-rc.0",
-        "@react-loosely-lazy/integration-app": "^1.0.0",
-        "@react-loosely-lazy/manifest": "^1.0.0"
+        "@react-loosely-lazy/integration-app": "^1.1.0",
+        "@react-loosely-lazy/manifest": "^1.1.0"
       }
     },
     "@react-loosely-lazy/parcel-transformer": {
@@ -22078,14 +22078,14 @@
         "@parcel/config-default": "2.0.0-rc.0",
         "@parcel/core": "2.0.0-rc.0",
         "@parcel/plugin": "^2.0.0-rc.0",
-        "@react-loosely-lazy/integration-app": "^1.0.0"
+        "@react-loosely-lazy/integration-app": "^1.1.0"
       }
     },
     "@react-loosely-lazy/webpack-plugin": {
       "version": "file:packages/plugins/webpack",
       "requires": {
-        "@react-loosely-lazy/integration-app": "^1.0.0",
-        "@react-loosely-lazy/manifest": "^1.0.0",
+        "@react-loosely-lazy/integration-app": "^1.1.0",
+        "@react-loosely-lazy/manifest": "^1.1.0",
         "@types/mini-css-extract-plugin": "^1.4.3",
         "@types/react": "^16.14.8",
         "@types/react-dom": "^16.9.13",
@@ -22094,7 +22094,7 @@
         "mini-css-extract-plugin": "^1.6.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-loosely-lazy": "1.0.0",
+        "react-loosely-lazy": "1.1.0",
         "tsconfig-paths-webpack-plugin": "^3.5.1",
         "webpack": "^4.46.0"
       }

--- a/packages/core/manifest/package.json
+++ b/packages/core/manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/manifest",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "react-loosely-lazy manifest types and utilities",
   "keywords": [
     "react-loosely-lazy",

--- a/packages/core/react-loosely-lazy/package.json
+++ b/packages/core/react-loosely-lazy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loosely-lazy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Suspense enable and SSR compatible async components with priorities",
   "keywords": [
     "react",
@@ -32,7 +32,7 @@
     "react-dom": "^16.14.0"
   },
   "peerDependencies": {
-    "@react-loosely-lazy/manifest": "1.0.0",
+    "@react-loosely-lazy/manifest": "1.1.0",
     "react": "^16.9.0 || ^17.0.0-0"
   }
 }

--- a/packages/core/react-loosely-lazy/src/lazy-wait/__tests__/lazy-wait.integration.test.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy-wait/__tests__/lazy-wait.integration.test.tsx
@@ -8,6 +8,11 @@ import { LazySuspense } from '../../suspense';
 
 import { LazyWait } from '../index';
 
+jest.mock('../../utils', () => ({
+  ...jest.requireActual<any>('../../utils'),
+  isNodeEnvironment: () => false,
+}));
+
 describe('LazyWait', () => {
   let loader: jest.Mock;
   beforeEach(() => {

--- a/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
@@ -18,8 +18,10 @@ import { ProfilerContext } from '../../profiler';
 import type { Status } from './types';
 import { useSubscription } from './utils';
 
-// @ts-expect-error requestIdleCallback might not exist
-const { requestIdleCallback = setTimeout } = window;
+const safeIdleCallback = (cb: () => void) => {
+  // @ts-expect-error requestIdleCallback might not exist
+  (window.requestIdleCallback ?? window.setTimeout)(cb);
+};
 
 export function createComponentClient<C extends ComponentType<any>>({
   defer,
@@ -94,7 +96,7 @@ export function createComponentClient<C extends ComponentType<any>>({
       useMemo(() => {
         if (!status.preloaded) {
           status.preloaded = true;
-          requestIdleCallback(() => {
+          safeIdleCallback(() => {
             if (status.started) return;
             preloadAsset({
               loader: deferred.preload,

--- a/packages/core/react-loosely-lazy/src/lazy/preload/__tests__/index.test.ts
+++ b/packages/core/react-loosely-lazy/src/lazy/preload/__tests__/index.test.ts
@@ -7,6 +7,11 @@ import {
 } from '..';
 import type { Cleanup } from '..';
 
+jest.mock('../../../utils', () => ({
+  ...jest.requireActual<any>('../../../utils'),
+  isNodeEnvironment: () => false,
+}));
+
 let head: string;
 
 beforeEach(() => {

--- a/packages/core/react-loosely-lazy/src/utils/index.ts
+++ b/packages/core/react-loosely-lazy/src/utils/index.ts
@@ -10,12 +10,31 @@ export const displayNameFromId = (id: string) => {
 
 /**
  * Checks to see if we are running inside a node environment or not.
- * Covers jsdom environments.
+ * Covers jsdom environments and other environments which simply remove
+ * window.
  *
  * @see https://github.com/jsdom/jsdom/issues/1537
  */
 export const isNodeEnvironment = () => {
-  return globalThis !== globalThis.window;
+  // Some SSR environments remove the window object
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  // Official way to check for JSDOM
+  if (
+    navigator.userAgent.includes('Node.js') ||
+    navigator.userAgent.includes('jsdom')
+  ) {
+    return true;
+  }
+
+  // Used by examples to immitate SSR
+  if (window.name === 'nodejs') {
+    return true;
+  }
+
+  return false;
 };
 
 export function attrToProp(props: { [k: string]: string }, attr: Attr) {

--- a/packages/plugins/babel/package.json
+++ b/packages/plugins/babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/babel-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Babel plugin for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",

--- a/packages/plugins/parcel-reporter-manifest/package.json
+++ b/packages/plugins/parcel-reporter-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/parcel-reporter-manifest",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parcel reporter plugin that generates a manifest for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",
@@ -34,11 +34,11 @@
     "@parcel/core": "2.0.0-rc.0",
     "@parcel/fs": "2.0.0-rc.0",
     "@parcel/types": "2.0.0-rc.0",
-    "@react-loosely-lazy/integration-app": "^1.0.0",
-    "@react-loosely-lazy/manifest": "^1.0.0"
+    "@react-loosely-lazy/integration-app": "^1.1.0",
+    "@react-loosely-lazy/manifest": "^1.1.0"
   },
   "peerDependencies": {
-    "@react-loosely-lazy/manifest": "1.0.0"
+    "@react-loosely-lazy/manifest": "1.1.0"
   },
   "engines": {
     "parcel": "^2.0.0-rc.0"

--- a/packages/plugins/parcel-transformer/package.json
+++ b/packages/plugins/parcel-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/parcel-transformer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parcel transformer plugin for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@parcel/config-default": "2.0.0-rc.0",
     "@parcel/core": "2.0.0-rc.0",
-    "@react-loosely-lazy/integration-app": "^1.0.0"
+    "@react-loosely-lazy/integration-app": "^1.1.0"
   },
   "engines": {
     "parcel": "^2.0.0-rc.0"

--- a/packages/plugins/webpack/package.json
+++ b/packages/plugins/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/webpack-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Webpack plugin for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",
@@ -25,8 +25,8 @@
     "dist"
   ],
   "devDependencies": {
-    "@react-loosely-lazy/integration-app": "^1.0.0",
-    "@react-loosely-lazy/manifest": "^1.0.0",
+    "@react-loosely-lazy/integration-app": "^1.1.0",
+    "@react-loosely-lazy/manifest": "^1.1.0",
     "@types/mini-css-extract-plugin": "^1.4.3",
     "@types/react": "^16.14.8",
     "@types/react-dom": "^16.9.13",
@@ -35,12 +35,12 @@
     "mini-css-extract-plugin": "^1.6.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-loosely-lazy": "1.0.0",
+    "react-loosely-lazy": "1.1.0",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "webpack": "^4.46.0"
   },
   "peerDependencies": {
-    "@react-loosely-lazy/manifest": "1.0.0",
+    "@react-loosely-lazy/manifest": "1.1.0",
     "webpack": "^4.x"
   }
 }

--- a/packages/testing/integration-app/package.json
+++ b/packages/testing/integration-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/integration-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Common application used for plugin integration tests",
   "keywords": [
@@ -21,7 +21,7 @@
   "source": "src/index.tsx",
   "dependencies": {
     "react": "^16.14.0",
-    "react-loosely-lazy": "^1.0.0"
+    "react-loosely-lazy": "^1.1.0"
   },
   "devDependencies": {
     "@types/react": "^16.14.8"


### PR DESCRIPTION
- Fixed an issue with isNodeEnvironment which does not work in environments which have removed the window object
- Brought back an older method for identifying node environment as it's needed to run the examples in an "ssr-like" environment
- Fixed an issue where `v8-snapshot` would fail due to an early `setTimout` access.