### PR TITLE
fix: PlaceholderFallbackRender can call replacement effect twice

### DIFF
--- a/packages/core/react-loosely-lazy/src/lazy/placeholders/render.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy/placeholders/render.tsx
@@ -27,8 +27,10 @@ const usePlaceholderRender = (resolveId: string, content: HTMLElement[]) => {
         node.parentNode?.removeChild(node)
       );
     };
+    // [hydrationRef.current, ssrDomNodes] are expected to be stable
+    // with the second one never changing by design and the first one changing after first render
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hydrationRef.current, ssrDomNodes]);
+  }, []);
 
   return hydrationRef;
 };


### PR DESCRIPTION
In some conditions `PlaceholderFallbackRender` can be rendered twice (for example parent component re-renders) causing `useEffect` to retrigger as `hydrationRef.current` changes.

It's a rule of thumb - dom refs should not be used in effect dependencies as they are given values __after__ hook execution. In such conditions, the secondary render will cause the effect to trigger as `hydrationRef.current` went from `null` to a particular value.