### PR TITLE
Add caret to parcel/plugin

### DIFF
--- a/packages/plugins/parcel-reporter-manifest/package.json
+++ b/packages/plugins/parcel-reporter-manifest/package.json
@@ -27,7 +27,7 @@
     "dist"
   ],
   "dependencies": {
-    "@parcel/plugin": "2.0.0-rc.0"
+    "@parcel/plugin": "^2.0.0-rc.0"
   },
   "devDependencies": {
     "@parcel/config-default": "2.0.0-rc.0",


### PR DESCRIPTION
As part of PR #85 the `@parcel/plugin` dependency was set to `^2.0.0-rc.0` for `parcel-transformer` but not `parcel-reporter-manifest`. There is no need for it to be pinned to `2.0.0-rc.0` - this is causing issues on node 18 due to the `lmdb-store` transitive dependency.