### PR TITLE
Bugfix - Parcel transformer regex

### DIFF
--- a/packages/plugins/parcel-transformer/package.json
+++ b/packages/plugins/parcel-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/parcel-transformer",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Parcel transformer plugin for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",

--- a/packages/plugins/parcel-transformer/package.json
+++ b/packages/plugins/parcel-transformer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-loosely-lazy/parcel-transformer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Parcel transformer plugin for react-loosely-lazy",
   "keywords": [
     "react-loosely-lazy",

--- a/packages/plugins/parcel-transformer/src/utils.ts
+++ b/packages/plugins/parcel-transformer/src/utils.ts
@@ -56,7 +56,7 @@ export const findUsages = (code: string, importSpecifiers: Set<string>) => {
   const usages: string[] = [];
   for (const importSpecifier of importSpecifiers) {
     // This is going to assume you call the library, with an optional generic type parameter, and no whitespace...
-    const usageStartRe = new RegExp(`${importSpecifier}(?:<.+>)?\\(`);
+    const usageStartRe = new RegExp(`${importSpecifier}(?:<(?:.|\n)+?>)?\\(`);
 
     let usageIndex = 0;
     let usageStart;


### PR DESCRIPTION
The regex used by the Parcel transformer was missing certain matches 