### PR TITLE
Export profiler EventInfo type

### DIFF
--- a/packages/core/react-loosely-lazy/src/index.ts
+++ b/packages/core/react-loosely-lazy/src/index.ts
@@ -28,3 +28,4 @@ export type { Fallback, LazySuspenseProps } from './suspense';
 export { useLazyPhase } from './phase';
 
 export { GlobalReactLooselyLazyProfiler, ProfilerContext } from './profiler';
+export type { EventInfo } from './profiler';


### PR DESCRIPTION
Profiler EventInfo type is missing from the exports.
Added it to the export.