### PR TITLE
Add custom resolver support

### DIFF
--- a/.changeset/chatty-shirts-repeat.md
+++ b/.changeset/chatty-shirts-repeat.md
@@ -2,4 +2,4 @@
 '@react-loosely-lazy/babel-plugin': minor
 ---
 
-Adding custom resolver support to babel-plugin
+Add custom resolver support

--- a/.changeset/chatty-shirts-repeat.md
+++ b/.changeset/chatty-shirts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@react-loosely-lazy/babel-plugin': minor
+---
+
+Adding custom resolver support to babel-plugin

--- a/packages/plugins/babel/__tests__/__fixtures__/resolver/index.js
+++ b/packages/plugins/babel/__tests__/__fixtures__/resolver/index.js
@@ -1,0 +1,11 @@
+const { join } = require('path');
+
+module.exports = {
+  resolveSync(_, filename, importPath) {
+    if (importPath === '@custom-package') {
+      return join(__dirname, 'local-custom-package/index.js');
+    }
+
+    throw new Error('Unreachable code');
+  },
+};

--- a/packages/plugins/babel/src/index.ts
+++ b/packages/plugins/babel/src/index.ts
@@ -1,6 +1,6 @@
 import { types as BabelTypes } from '@babel/core';
 import type { NodePath, PluginObj } from '@babel/core';
-import { ResolveOptions } from 'enhanced-resolve';
+import { ResolveOptions, Resolver } from 'enhanced-resolve';
 
 import {
   createCustomResolver,
@@ -28,6 +28,7 @@ export type BabelPluginOptions = Partial<{
   modulePathReplacer: ModulePathReplacer;
   noopRedundantLoaders: boolean;
   resolverOptions: Partial<ResolveOptions> | undefined;
+  resolver: Resolver | undefined;
 }>;
 
 export default function ({
@@ -262,10 +263,14 @@ export default function ({
           modulePathReplacer,
           noopRedundantLoaders = true,
           resolverOptions = {},
+          resolver,
         } = state.opts || {};
         const { filename } = state;
         const source = path.node.source.value;
-        const customResolver = createCustomResolver(resolverOptions);
+        const customResolver = 
+          resolver && typeof resolver === 'string' ? 
+            require(require.resolve(resolver)) : 
+            createCustomResolver(resolverOptions);
 
         if (source !== PACKAGE_NAME) {
           return;

--- a/packages/plugins/babel/src/index.ts
+++ b/packages/plugins/babel/src/index.ts
@@ -265,15 +265,15 @@ export default function ({
           noopRedundantLoaders = true,
           resolverOptions = {},
           resolver,
-          root
+          root,
         } = state.opts || {};
         const { filename } = state;
         const source = path.node.source.value;
         const customResolver =
           resolver && typeof resolver === 'string'
             ? require(require.resolve(resolver, {
-              paths: [root ?? this.cwd],
-            }))
+                paths: [root ?? this.cwd],
+              }))
             : createCustomResolver(resolverOptions);
 
         if (source !== PACKAGE_NAME) {

--- a/packages/plugins/babel/src/index.ts
+++ b/packages/plugins/babel/src/index.ts
@@ -1,6 +1,6 @@
 import { types as BabelTypes } from '@babel/core';
 import type { NodePath, PluginObj } from '@babel/core';
-import { ResolveOptions, Resolver } from 'enhanced-resolve';
+import { ResolveOptions } from 'enhanced-resolve';
 
 import {
   createCustomResolver,
@@ -28,7 +28,7 @@ export type BabelPluginOptions = Partial<{
   modulePathReplacer: ModulePathReplacer;
   noopRedundantLoaders: boolean;
   resolverOptions: Partial<ResolveOptions> | undefined;
-  resolver: Resolver | undefined;
+  resolver: string | undefined;
 }>;
 
 export default function ({

--- a/packages/plugins/babel/src/index.ts
+++ b/packages/plugins/babel/src/index.ts
@@ -29,6 +29,7 @@ export type BabelPluginOptions = Partial<{
   noopRedundantLoaders: boolean;
   resolverOptions: Partial<ResolveOptions> | undefined;
   resolver: string | undefined;
+  root: string | undefined;
 }>;
 
 export default function ({
@@ -264,12 +265,15 @@ export default function ({
           noopRedundantLoaders = true,
           resolverOptions = {},
           resolver,
+          root
         } = state.opts || {};
         const { filename } = state;
         const source = path.node.source.value;
         const customResolver =
           resolver && typeof resolver === 'string'
-            ? require(require.resolve(resolver))
+            ? require(require.resolve(resolver, {
+              paths: [root ?? this.cwd],
+            }))
             : createCustomResolver(resolverOptions);
 
         if (source !== PACKAGE_NAME) {

--- a/packages/plugins/babel/src/index.ts
+++ b/packages/plugins/babel/src/index.ts
@@ -267,10 +267,10 @@ export default function ({
         } = state.opts || {};
         const { filename } = state;
         const source = path.node.source.value;
-        const customResolver = 
-          resolver && typeof resolver === 'string' ? 
-            require(require.resolve(resolver)) : 
-            createCustomResolver(resolverOptions);
+        const customResolver =
+          resolver && typeof resolver === 'string'
+            ? require(require.resolve(resolver))
+            : createCustomResolver(resolverOptions);
 
         if (source !== PACKAGE_NAME) {
           return;


### PR DESCRIPTION
Adding support for custom `resolver` to babel plugin

Example:
```
[
    "@react-loosely-lazy/babel-plugin",
    {
        "client": false,
        "resolver": "@atlassian/jira-dev-rll-resolver"
    }
],
```