### PR TITLE
Avoid 'window' access during module initialization

### DIFF
--- a/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
@@ -18,8 +18,7 @@ import { ProfilerContext } from '../../profiler';
 import type { Status } from './types';
 import { useSubscription } from './utils';
 
-// @ts-expect-error requestIdleCallback might not exist
-const { requestIdleCallback = setTimeout } = window;
+
 
 export function createComponentClient<C extends ComponentType<any>>({
   defer,
@@ -32,6 +31,9 @@ export function createComponentClient<C extends ComponentType<any>>({
   dataLazyId: string;
   moduleId: string;
 }) {
+  
+  // @ts-expect-error requestIdleCallback might not exist
+  const { requestIdleCallback = setTimeout } = window;
   const ResolvedLazy = lazy(() => deferred.promise);
 
   return (props: ComponentProps<C>) => {

--- a/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
+++ b/packages/core/react-loosely-lazy/src/lazy/components/client.tsx
@@ -17,9 +17,6 @@ import { ProfilerContext } from '../../profiler';
 
 import type { Status } from './types';
 import { useSubscription } from './utils';
-
-
-
 export function createComponentClient<C extends ComponentType<any>>({
   defer,
   deferred,
@@ -31,7 +28,6 @@ export function createComponentClient<C extends ComponentType<any>>({
   dataLazyId: string;
   moduleId: string;
 }) {
-  
   // @ts-expect-error requestIdleCallback might not exist
   const { requestIdleCallback = setTimeout } = window;
   const ResolvedLazy = lazy(() => deferred.promise);


### PR DESCRIPTION
Moving the scheduler access inside the component. It is assumed that this would not be used in a non-browser environment.